### PR TITLE
Davifoxosu storage mibs update disk speeds

### DIFF
--- a/ucs-mibs/CISCO-UNIFIED-COMPUTING-STORAGE-MIB.my
+++ b/ucs-mibs/CISCO-UNIFIED-COMPUTING-STORAGE-MIB.my
@@ -6104,7 +6104,9 @@ CucsStorageLocalDiskEntry ::= SEQUENCE {
     cucsStorageLocalDiskVariantType                                  SnmpAdminString,
     cucsStorageLocalDiskAdminSecurityKey                             SnmpAdminString,
     cucsStorageLocalDiskDriveState                                   CucsStorageDriveFlags,
-    cucsStorageLocalDiskErrDescription                               SnmpAdminString
+    cucsStorageLocalDiskErrDescription                               SnmpAdminString,
+    cucsStorageLocalDiskNegotiatedWidth                              Unsigned32,
+    cucsStorageLocalDiskMaxWidth                                     Unsigned32
 }
 
 cucsStorageLocalDiskInstanceId OBJECT-TYPE
@@ -6515,6 +6517,24 @@ cucsStorageLocalDiskErrDescription OBJECT-TYPE
         "Cisco UCS storage:LocalDisk:errDescription managed
         object property"
     ::= { cucsStorageLocalDiskEntry 49 }
+
+cucsStorageLocalDiskNegotiatedWidth OBJECT-TYPE
+    SYNTAX       Unsigned32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Cisco UCS storage:LocalDisk:Negotiated Pci Width managed object property"
+        object property"
+    ::= { cucsStorageLocalDiskEntry 50 }
+ 
+ cucsStorageLocalDiskMaxWidth OBJECT-TYPE
+    SYNTAX       Unsigned32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Cisco UCS storage:LocalDisk:Max Pci Width managed object property"
+        object property"
+    ::= { cucsStorageLocalDiskEntry 51 }
 
 cucsStorageLocalDiskConfigDefTable OBJECT-TYPE
     SYNTAX           SEQUENCE OF CucsStorageLocalDiskConfigDefEntry

--- a/ucs-mibs/CISCO-UNIFIED-COMPUTING-TC-MIB.my
+++ b/ucs-mibs/CISCO-UNIFIED-COMPUTING-TC-MIB.my
@@ -49139,7 +49139,12 @@ CucsStorageLinkSpeed ::= TEXTUAL-CONVENTION
         down(5),
         hostPowerOff(6),
         unsupportedDevice(7),
-        disabled(8)
+        disabled(8),
+        n24Gbps(9),
+        n2.5GT(10),
+        n5.0GT(11),
+        n8.0GT(12),
+        n16.0GT(13),
     }
 
 CucsStorageLocalDiskDiscoveredPath ::= TEXTUAL-CONVENTION


### PR DESCRIPTION
Update UCS Storage MIBs. Updated disk speeds with newer values.  Updated localdisk MIB with two more fields  cucsStorageLocalDiskNegotiatedWidth, cucsStorageLocalDiskMaxWidth.