### PR TITLE
Fix lwapp mibs

### DIFF
--- a/v2/CISCO-LWAPP-AP-MIB.my
+++ b/v2/CISCO-LWAPP-AP-MIB.my
@@ -4268,7 +4268,7 @@ cLApSlotWlanStatsEntry OBJECT-TYPE
                         cLApDot11IfSlotId,
                         cLWlanIndex
                     }
-    ::= { cLApSlotWlanStatsTable 1 }
+    ::= { cLApWlanSlotStatsTable 1 }
 
 CLApSlotWlanStatsEntry ::= SEQUENCE {
         cLApSlotWlanStatsTxPktNum       Counter64,

--- a/v2/CISCO-LWAPP-REAP-MIB.my
+++ b/v2/CISCO-LWAPP-REAP-MIB.my
@@ -2029,7 +2029,7 @@ cLReapGroupPMKAPPropagation OBJECT-TYPE
          controller to only few APs and from those AP to other APs in
          site tag.
          A value of 'pmkDistDCDS' specifies PMK distribution between 
-         APs in site tag.
+         APs in site tag."
     
     DEFVAL          { pmkDistCntrToAp } 
     ::= { cLReapGroupConfigEntry 57 }


### PR DESCRIPTION
Proposed fix of two minor issues in LWAPP mibs

- `cLApSlotWlanStatsTable` is misspelled and should be `cLApWlanSlotStatsTable`
- Missing a double quote in description