### PR TITLE
CSCwi37700 CISCO-SWITCH-ENGINE-MIB: missing enum 310

### DIFF
--- a/v2/CISCO-SWITCH-ENGINE-MIB.my
+++ b/v2/CISCO-SWITCH-ENGINE-MIB.my
@@ -9,7 +9,7 @@
 -- August 2003, Edward Pham
 -- %DNP% March 2005, Jayakumar Kadirvelu
 --   
--- Copyright (c) 2000-2021 by cisco Systems Inc.
+-- Copyright (c) 2000-2024 by cisco Systems Inc.
 -- by cisco Systems, Inc.
 -- All rights reserved.
 -- *****************************************************************
@@ -60,7 +60,7 @@ IMPORTS
 
 
 ciscoSwitchEngineMIB MODULE-IDENTITY
-    LAST-UPDATED    "202005260000Z"
+    LAST-UPDATED    "202401090000Z"
     ORGANIZATION    "Cisco Systems Inc."
     CONTACT-INFO
             "Cisco Systems
@@ -97,6 +97,9 @@ ciscoSwitchEngineMIB MODULE-IDENTITY
         Layer 2 forwarding. However, they can also learn 'flows' through
         other physically-separate (external) Cisco routers that are
         connected to the switch-engine through the network."
+    REVISION        "202401090000Z"
+    DESCRIPTION
+        "Add enumerated value 310 - 313 to cseTcamResourceType."
     REVISION        "202108010000Z"
     DESCRIPTION
         "Add enumerated value 309 to cseTcamResourceType."
@@ -4702,7 +4705,11 @@ cseTcamResourceType OBJECT-TYPE
                         ingressL2L3QosAll(306),
                         natRewriteTable(307),
                         tcpAwareNat(308),
-                        ingressNetflowSvi(309)
+                        ingressNetflowSvi(309),
+                        ingressIpv6Span(310),
+                        ingressFlowPathTracerIpv4(311),
+                        ingressFlowPathTracerIpv6(312),
+                        analyticsFilterTcam(313)
                     }
     MAX-ACCESS      not-accessible
     STATUS          current
@@ -5629,7 +5636,19 @@ cseTcamResourceType OBJECT-TYPE
         Aware NAT.
 
         ingressNetflowSvi(309) indicates that TCAM space is allocated for
-        Ingress Netflow SVI."
+        Ingress Netflow SVI.
+
+        ingressIpv6Span(310) indicates that TCAM space is allocated for
+        Ingress IPV6 SPAN.
+
+        ingressFlowPathTracerIpv4(311) indicates that TCAM space is allocated for
+        Ingress Flow Path Tracer IPV4.
+
+        ingressFlowPathTracerIpv6(312) indicates that TCAM space is allocated for
+        Ingress Flow Path Tracer IPV6.
+
+        analyticsFilterTcam(313) indicates that TCAM space is allocated for
+        Analytics Filter TCAM."
         
     ::= { cseTcamUsageEntry 1 }
 


### PR DESCRIPTION
CISCO-SWITCH-ENGINE-MIB missing enum 310 for Ingress IPV6 SPAN resource.
Also 311,312, 313 are also added and updated in the MIB.