### PR TITLE
Update CISCO-UNIFIED-COMPUTING-TC-MIB.my

### DIFF
--- a/ucs-mibs/CISCO-UNIFIED-COMPUTING-TC-MIB.my
+++ b/ucs-mibs/CISCO-UNIFIED-COMPUTING-TC-MIB.my
@@ -49128,24 +49128,8 @@ CucsStorageLearnMode ::= TEXTUAL-CONVENTION
 CucsStorageLinkSpeed ::= TEXTUAL-CONVENTION
     STATUS        current
     DESCRIPTION
-        ""
-    SYNTAX        INTEGER
-    {
-        unknown(0),
-        n15Gbps(1),
-        n3Gbps(2),
-        n6Gbps(3),
-        n12Gbps(4),
-        down(5),
-        hostPowerOff(6),
-        unsupportedDevice(7),
-        disabled(8),
-        n24Gbps(9),
-        n25GT(10),
-        n50GT(11),
-        n80GT(12),
-        n160GT(13),
-    }
+        "Display Link speed as a string"
+    SYNTAX       OCTET STRING
 
 CucsStorageLocalDiskDiscoveredPath ::= TEXTUAL-CONVENTION
     STATUS        current


### PR DESCRIPTION
Moving integer base field "Link Speed" to string based field. This change should prevent the need for future changes to this field as newer speeds come out.