### PR TITLE
CSCwj58838: walk cucsProcessorUnitTable, the value of cucsProcessorUn…

### DIFF
--- a/ucs-mibs/CISCO-UNIFIED-COMPUTING-TC-MIB.my
+++ b/ucs-mibs/CISCO-UNIFIED-COMPUTING-TC-MIB.my
@@ -46617,6 +46617,7 @@ CucsProcessorArchitecture ::= TEXTUAL-CONVENTION
     {
         any(0),
         intelP4C(1),
+        zen(107),
         opteron(132),
         turion64(134),
         dualCoreOpteron(135),

--- a/ucs-mibs/CISCO-UNIFIED-COMPUTING-TC-MIB.my
+++ b/ucs-mibs/CISCO-UNIFIED-COMPUTING-TC-MIB.my
@@ -48169,15 +48169,6 @@ CucsStorageControllerForm ::= TEXTUAL-CONVENTION
         embedded(4)
     }
 
-CucsStorageControllerId ::= TEXTUAL-CONVENTION
-    STATUS        current
-    DESCRIPTION
-        ""
-    SYNTAX        INTEGER
-    {
-        all(0)
-    }
-
 CucsStorageControllerJBODMode ::= TEXTUAL-CONVENTION
     STATUS        current
     DESCRIPTION


### PR DESCRIPTION
Value of cucsProcessorUnitArch was appearing as Any when preforming an SNMP walk. Code has been updated (https://bitbucket-eng-sjc1.cisco.com/bitbucket/projects/CSPG/repos/sums/pull-requests/24898/overview) to fix this and now MIB must also be updated.

Image of issue:
![SNMP Walk](https://github.com/cisco/cisco-mibs/assets/167934351/a2fbc70e-581b-414e-a774-4ea332205e6f)
