### PR TITLE
CSCwn43339: ciscoSwitchEngineMIB missing quite a few tcam resource en…

### DIFF
--- a/v2/CISCO-SWITCH-ENGINE-MIB.my
+++ b/v2/CISCO-SWITCH-ENGINE-MIB.my
@@ -4714,7 +4714,18 @@ cseTcamResourceType OBJECT-TYPE
                         egressNetflowL2(315),
                         egressNetflowSvi(316),
                         labelLblAHv1(317),
-                        labelLblAIv1(318)
+                        labelLblAIv1(318),
+                        IngressAnalyticsL2V4(319),
+                        IngressAnalyticsL2V6(320),
+                        IngressAnalyticsL3V4(321),
+                        IngressAnalyticsL3V6(322),
+                        IngressAnalyticsMAC(323),
+                        EgressAnalyticsL3V4(324),
+                        EgressAnalyticsL3V6(325),
+                        ingressSvcRedirP1v4(326),
+                        ingressSvcRedirP1v6(327),
+                        ingressSvcRedirP2v4(328),
+                        ingressSvcRedirP2v6(329)
                     }
     MAX-ACCESS      not-accessible
     STATUS          current


### PR DESCRIPTION
…tries in cseTcamUsageTable

Added the following:
CISCO-SWITCH-ENGINE-MIB::cseTcamResourceDescr.116953.319 = STRING: Ingress Analytics L2V4
CISCO-SWITCH-ENGINE-MIB::cseTcamResourceDescr.116953.320 = STRING: Ingress Analytics L2V6
CISCO-SWITCH-ENGINE-MIB::cseTcamResourceDescr.116953.321 = STRING: Ingress Analytics L3V4
CISCO-SWITCH-ENGINE-MIB::cseTcamResourceDescr.116953.322 = STRING: Ingress Analytics L3V6
CISCO-SWITCH-ENGINE-MIB::cseTcamResourceDescr.116953.323 = STRING: Ingress Analytics MAC
CISCO-SWITCH-ENGINE-MIB::cseTcamResourceDescr.116953.324 = STRING: Egress Analytics L3V4
CISCO-SWITCH-ENGINE-MIB::cseTcamResourceDescr.116953.325 = STRING: Egress Analytics L3V6
CISCO-SWITCH-ENGINE-MIB::cseTcamResourceDescr.116953.326 = STRING: Ingress SVC Redir Policy Pass-1-IPV4
CISCO-SWITCH-ENGINE-MIB::cseTcamResourceDescr.116953.327 = STRING: Ingress SVC Redir Policy Pass-1-IPV6
CISCO-SWITCH-ENGINE-MIB::cseTcamResourceDescr.116953.328 = STRING: Ingress SVC Redir Policy Pass-2-IPV4
CISCO-SWITCH-ENGINE-MIB::cseTcamResourceDescr.116953.329 = STRING: Ingress SVC Redir Policy Pass-2-IPV6
