### PR TITLE
Fix CISCO-LWAPP MIBS errors

### DIFF
--- a/v2/CISCO-LWAPP-RF-MIB.my
+++ b/v2/CISCO-LWAPP-RF-MIB.my
@@ -196,7 +196,7 @@ ciscoLwappRFMIB MODULE-IDENTITY
          - cLRFProfileMultiBssidProfile
          Added new table cLMultiBSSIDProfileTable
          Added conformance group ciscoLwappRFConfigGroup10
-         Added compliance group ciscoLwappRFMIBComplianceRev7".
+         Added compliance group ciscoLwappRFMIBComplianceRev7."
     REVISION        "202009020000Z"
     DESCRIPTION
         "Added below object to the cLRFProfileTable

--- a/v2/CISCO-LWAPP-RF-MIB.my
+++ b/v2/CISCO-LWAPP-RF-MIB.my
@@ -1138,8 +1138,8 @@ cLRFProfileNdpMode OBJECT-TYPE
 cLRFProfile11ax6GHzFeature OBJECT-TYPE
      SYNTAX          INTEGER  {
                          none(0),
-                         bcast_probe_response(1),
-                         fils_discovery(2)
+                         bcastproberesponse(1),
+                         filsdiscovery(2)
                      }
      MAX-ACCESS      read-write
      STATUS          current

--- a/v2/CISCO-LWAPP-RF-MIB.my
+++ b/v2/CISCO-LWAPP-RF-MIB.my
@@ -1750,7 +1750,7 @@ cLMultiBSSIDProfile11beOfdmaMultiRU OBJECT-TYPE
     DEFVAL          { false }
     ::= { cLMultiBSSIDProfileEntry 14 }
 
-cLMultiBSSIDProfileRowStatus OBJECT-TYPE
+
 -- ********************************************************************
 -- *    Compliance statements
 -- ********************************************************************

--- a/v2/CISCO-LWAPP-TC-MIB.my
+++ b/v2/CISCO-LWAPP-TC-MIB.my
@@ -248,10 +248,10 @@ CLApIfType ::= TEXTUAL-CONVENTION
         rlan - This value indicates that this is a RLAN
 	interface.
 
-        dot11_6ghz - This value indicates that the radio
+        dot116ghz - This value indicates that the radio
 	interface is following 802.11 6ghz standard.
 
-	dot11_xor_5_6ghz - This value indicates that the
+	dot11xor56ghz - This value indicates that the
 	radio interface is operating in XOR mode between
 	802.11a and 802.11 6ghz."
 
@@ -261,8 +261,8 @@ CLApIfType ::= TEXTUAL-CONVENTION
                         uwb(3),
                         dot11abgn(4),
                         rlan(5),
-                        dot11_6ghz(6),
-                        dot11_xor_5_6ghz(7)
+                        dot116ghz(6),
+                        dot11xor56ghz(7)
                     }
 
 CLDot11Channel ::= TEXTUAL-CONVENTION


### PR DESCRIPTION
Changes:
- Fix typo in comments
- Underscore character is not a legal character for SNMP MIB syntax
- Remove duplicate cLMultiBSSIDProfileRowStatus def