### PR TITLE
Update CISCO-RTTMON-TC-MIB.my

### DIFF
--- a/v2/CISCO-RTTMON-TC-MIB.my
+++ b/v2/CISCO-RTTMON-TC-MIB.my
@@ -428,7 +428,7 @@ RttMonRttType ::= TEXTUAL-CONVENTION
 
         The value 'fabricPathEcho' will cause the RTT application to
         perform delay performance measurment and verify connectivity in
-        a Fabric Path Network."
+        a Fabric Path Network.
 
         NOTE:  The 'pathJitter' time delay operation is a heuristic
                measurement because an intermediate hop may forward


### PR DESCRIPTION
Observed errors from snmptranslate for this file.  Commit bea79635a840cd2d3a62f0f8627e57915e0251fc on Dec 23, 2022 added a NOTE but is missing a " before or didn't remove the previous " so the NOTE would be part of the description text.