### PR TITLE
Correct syntax errors

### DIFF
--- a/v2/CISCO-FC-FE-MIB.my
+++ b/v2/CISCO-FC-FE-MIB.my
@@ -7049,10 +7049,10 @@ cffFcFeMIBComplianceRev17 MODULE-COMPLIANCE
     DESCRIPTION
         "Write access is not required."
 
-    OBJECT          TransceiverPowerControl
-    MIN-ACCESS      read-only
-    DESCRIPTION
-        "Write access is not required."
+--  OBJECT          TransceiverPowerControl
+--  MIN-ACCESS      read-only
+--  DESCRIPTION
+--      "Write access is not required."
 
     ::= { cffFcFeMIBCompliances 19 }
 
@@ -7651,7 +7651,7 @@ fcIfGroupRev6 OBJECT-GROUP
         				fcIfTransceiverPower,
         				fcIfTransceiverPowerControl,
         				fcIfSysTransceiverPowerControlCapability,
-        				fcIfSysTransceiverPowerControl,
+        				fcIfSysTransceiverPowerControl
                     }
     STATUS          current
     DESCRIPTION

--- a/v2/CISCO-ST-TC.my
+++ b/v2/CISCO-ST-TC.my
@@ -362,7 +362,7 @@ FcIfSpeed ::= TEXTUAL-CONVENTION
           thirtyTwoG  (12) - 32GBit.
           autoMaxThirtyTwoG (13) - Negotiate to determine the
                              speed automatically upto a
-                             maximum of 32Gbit."
+                             maximum of 32Gbit.
           fiftyG      (14) - 50GBit.
           sixtyFourG  (15) - 64GBit.
           autoMaxSixtyFourG (16) - Negotiate to determine the


### PR DESCRIPTION
This fixes three parse errors in the Cisco MIBs:

1. An erroneous quote (") in a description
2. An erroneous comma in an OBJECT-GROUP definition
3. A reference to an unknown OBJECT-GROUP "TransceiverPowerControl"
