### PR TITLE
Update CISCO-ST-TC.my

### DIFF
--- a/v2/CISCO-ST-TC.my
+++ b/v2/CISCO-ST-TC.my
@@ -362,7 +362,7 @@ FcIfSpeed ::= TEXTUAL-CONVENTION
           thirtyTwoG  (12) - 32GBit.
           autoMaxThirtyTwoG (13) - Negotiate to determine the
                              speed automatically upto a
-                             maximum of 32Gbit."
+                             maximum of 32Gbit.
           fiftyG      (14) - 50GBit.
           sixtyFourG  (15) - 64GBit.
           autoMaxSixtyFourG (16) - Negotiate to determine the


### PR DESCRIPTION
The double-quotation in the end of Line#365 seems an extra, and preventing this MIB file to be loaded properly. Would like to suggest to remove it.