### PR TITLE
fix: Update cpmCoreIndex constraint in CISCO-PROCESS-MIB to include index 0

### DIFF
--- a/v1/CISCO-PROCESS-MIB-V1SMI.my
+++ b/v1/CISCO-PROCESS-MIB-V1SMI.my
@@ -610,7 +610,7 @@ CpmCoreEntry ::= SEQUENCE {
     }
 
 cpmCoreIndex OBJECT-TYPE
-    SYNTAX Gauge(1..4294967295)
+    SYNTAX Gauge(0..4294967295)
     ACCESS not-accessible
     STATUS mandatory
     DESCRIPTION

--- a/v2/CISCO-PROCESS-MIB.my
+++ b/v2/CISCO-PROCESS-MIB.my
@@ -642,7 +642,7 @@ CpmCoreEntry ::= SEQUENCE {
 }
 
 cpmCoreIndex OBJECT-TYPE
-    SYNTAX          Unsigned32 (1..4294967295)
+    SYNTAX          Unsigned32 (0..4294967295)
     MAX-ACCESS      not-accessible
     STATUS          current
     DESCRIPTION


### PR DESCRIPTION
This Pull Request addresses a ValueConstraintError encountered when attempting to query the cpmCoreIndex object within the CISCO-PROCESS-MIB using SNMP, specifically when an index value of 0 is returned by a Cisco device.

When performing SNMP GET operations for cpmCoreIndex (e.g., as part of cpmCore5min or similar objects) using an SNMP client library (such as pysnmp in Python), a pyasn1.type.error.ValueConstraintError is raised if the device returns an instance with an index of 0.

```
iterator = getCmd(
    SnmpEngine(),
    CommunityData('public'),
    UdpTransportTarget(('<snmp-enabled-device>', 161)),
    ContextData(),
    ObjectType(ObjectIdentity('CISCO-PROCESS-MIB', 'cpmCore5min', 7, 0)),
)
```

The relevant portion of the error traceback indicates:

```
pyasn1.type.error.ValueConstraintError: <ValueRangeConstraint object, consts 1, 4294967295> failed at: ValueConstraintError(0)
...
pysnmp.smi.error.SmiError: Instance index (7, 0) to OID conversion failure at object 'cpmCore5min': ... failed at: ValueConstraintError(0)' at Unsigned32
```

This error occurs because the current MIB definition for cpmCoreIndex specifies its SYNTAX as Unsigned32 (1..4294967295). This constraint explicitly disallows an index value of 0. However, observations from various Cisco devices indicate that 0 can be a legitimate and valid index for cpmCoreIndex in certain scenarios.

The change will be from:
```
cpmCoreIndex OBJECT-TYPE
    SYNTAX      Unsigned32 (1..4294967295)
```
To:
```
cpmCoreIndex OBJECT-TYPE
    SYNTAX      Unsigned32 (0..4294967295)
```

This modification aligns the MIB definition with observed device behavior, preventing ValueConstraintError exceptions during SNMP operations that query cpmCoreIndex with a value of 0.

