### PR TITLE
publishing optical MIB

### DIFF
--- a/v2/CISCO-OPTICAL-OTS-MIB.my
+++ b/v2/CISCO-OPTICAL-OTS-MIB.my
@@ -1,10 +1,11 @@
 -- *****************************************************************
 -- CISCO-OPTICAL-OTS-MIB.my
 -- OPTICAL TRANSMISSION SECTION INTERFACE MIB
---   
+--
+--
 -- April 2020 ncs1001 Team
---   
--- Copyright (c) 2016, 2020 by Cisco Systems, Inc.
+--
+-- Copyright (c) 2016, 2020, 2022-2023, 2026 by Cisco Systems, Inc.
 -- All rights reserved.
 -- *****************************************************************
 
@@ -25,7 +26,8 @@ IMPORTS
         FROM SNMP-FRAMEWORK-MIB
     TEXTUAL-CONVENTION,
     TruthValue,
-    TimeStamp
+    TimeStamp,
+    DisplayString
         FROM SNMPv2-TC
     ifIndex,
     ifName
@@ -43,7 +45,7 @@ IMPORTS
 
 
 ciscoOpticalOtsMIB MODULE-IDENTITY
-    LAST-UPDATED    "202004080000Z"
+    LAST-UPDATED    "202602100000Z"
     ORGANIZATION    "Cisco Systems, Inc."
     CONTACT-INFO
             "Cisco Systems
@@ -63,9 +65,9 @@ ciscoOpticalOtsMIB MODULE-IDENTITY
             E-mail: cs-ncs1001@cisco.com"
     DESCRIPTION
         "This MIB module defines the managed objects and statistics
-        objects for physical layer characteristics of optical line 
-        systems and optical transport devices. 
-        Performance monitoring (PM) parameters are used to gather, 
+        objects for physical layer characteristics of optical line
+        systems and optical transport devices.
+        Performance monitoring (PM) parameters are used to gather,
         store, set thresholds for and report
         performance data for early detection of problems.
         Thresholds are used to set error levels for each PM parameter.
@@ -89,6 +91,131 @@ ciscoOpticalOtsMIB MODULE-IDENTITY
         dBm       : Decibel-milliwatt
         mW        : Milliwatt
         nm        : Nanometer."
+    REVISION        "202602100000Z"
+    DESCRIPTION
+        "Added cooOtsController2Table, Entry and new attributes
+
+        This table supersedes the earlier cooOtsControllerTable which used
+        only ifIndex as the INDEX. The previous design could not distinguish
+        between LINE and COM port attributes on the same physical interface
+        (e.g., different TX power, gain settings per port). The composite
+        INDEX structure { ifIndex, cooOtsController2PortType } was introduced
+        to support multi-port OLS modules where LINE and COM ports share an
+        ifIndex but require independent operational data"
+
+    REVISION        "202308020000Z"
+    DESCRIPTION
+        "- Added to  CooOtsControllerEntry new attribute:
+           cooOtsControllerEAmpliBrPower"
+
+    REVISION        "202301310000Z"
+    DESCRIPTION
+        "- Extended Lower range of CoiOpticalPower in imported
+           CISCO-OPTICAL-MIB to -5000,New range is -5000..3000
+
+         - Corrected description of RX VOA and TX VOA Attenuation
+           from 1/100 dBm to 1/100 dB as the unit is 1/100 dB."
+
+    REVISION        "202212090000Z"
+    DESCRIPTION
+        "- Added to CooOtsControllerEntry new attributes:
+           cooOtsControllerAmpliControlModeConfigVal
+           cooOtsControllerEAmpliPowerConfigVal
+           cooOtsControllerTemperature
+           cooOtsControllerVoltage
+         - Added new CooOtsControllerTransceiver Table & new attributes:
+           cooOtsControllerTransceiverVendorInfo
+         - Added new value power(3) to CiscoOpticalOtsAmpliControlMode."
+
+    REVISION        "202211100000Z"
+    DESCRIPTION
+         "- Changed unit from dBm to dB for below attributes:
+             cooOtsControllerRXSpanLoss
+             cooOtsControllerTXSpanLoss"
+
+    REVISION        "202209220000Z"
+    DESCRIPTION
+        "- Added new  CooOtsRamanEntry Table and  new attributes:
+            cooOtsRaman1TXPower
+            cooOtsRaman2TXPower
+            cooOtsRaman3TXPower
+            cooOtsRaman4TXPower
+            cooOtsRaman5TXPower
+            cooOtsRaman1Wavelength
+            cooOtsRaman2Wavelength
+            cooOtsRaman3Wavelength
+            cooOtsRaman4Wavelength
+            cooOtsRaman5Wavelength
+            cooOtsRamanCompositePower
+            cooOtsRamanOsri
+            cooOtsRamanSafetyControlMode
+            cooOtsRamanForceAPR
+            cooOtsRamanBRPower
+            cooOtsRamanBRRatio"
+
+    REVISION        "202209070000Z"
+    DESCRIPTION
+        "- Added to  CooOtsControllerEntry new attributes:
+           cooOtsControllerIAmpliGain
+           cooOtsControllerIAmpliTilt
+           cooOtsControllerIAmpliGainRange
+           cooOtsControllerISafetyControlMode
+           cooOtsControllerIAmpliOsri
+           cooOtsControllerEAmpliGain
+           cooOtsControllerEAmpliTilt
+           cooOtsControllerEAmpliGainRange
+           cooOtsControllerESafetyControlMode
+           cooOtsControllerEAmpliOsri
+           cooOtsControllerTotLCTXPower
+           cooOtsControllerTotLCRXPower
+           cooOtsControllerIForceApr
+           cooOtsControllerEForceApr
+           cooOtsControllerBrPower
+           cooOtsControllerLedState
+           cooOtsControllerEAmpliBrRatio"
+
+    REVISION        "202208240000Z"
+    DESCRIPTION
+        "- Added to CooOtsCurrentEntry new attributes:
+           cooCurrentTXPowerCLMin
+           cooCurrentTXPowerCLMax
+           cooCurrentTXPowerCLAvg
+           cooCurrentRXPowerCLMin
+           cooCurrentRXPowerCLMax
+           cooCurrentRXPowerCLAvg
+           cooCurrentIAmpliGainMin
+           cooCurrentIAmpliGainMax
+           cooCurrentIAmpliGainAvg
+           cooCurrentEAmpliGainMin
+           cooCurrentEAmpliGainMax
+           cooCurrentEAmpliGainAvg
+           cooCurrentIAmpliGainTiltMin
+           cooCurrentIAmpliGainTiltMax
+           cooCurrentIAmpliGainTiltAvg
+           cooCurrentEAmpliGainTiltMin
+           cooCurrentEAmpliGainTiltMax
+           cooCurrentEAmpliGainTiltAvg
+
+       - Added to CooOtsIntervalEntry new attributes:
+         cooIntervalTXPowerCLMin
+         cooIntervalTXPowerCLMax
+         cooIntervalTXPowerCLAvg
+         cooIntervalRXPowerCLMin
+         cooIntervalRXPowerCLMax
+         cooIntervalRXPowerCLAvg
+         cooIntervalIAmpliGainMin
+         cooIntervalIAmpliGainMax
+         cooIntervalIAmpliGainAvg
+         cooIntervalEAmpliGainMin
+         cooIntervalEAmpliGainMax
+         cooIntervalEAmpliGainAvg
+         cooIntervalIAmpliGainTiltMin
+         cooIntervalIAmpliGainTiltMax
+         cooIntervalIAmpliGainTiltAvg
+         cooIntervalEAmpliGainTiltMin
+         cooIntervalEAmpliGainTiltMax
+         cooIntervalEAmpliGainTiltAvg"
+
     REVISION        "202004080000Z"
     DESCRIPTION
         "- Modified cooOtsOchControllerFrequency description
@@ -103,7 +230,7 @@ ciscoOpticalOtsMIB MODULE-IDENTITY
         cooOtsControllerRXSpanLoss
         cooOtsControllerTXSpanLoss
         cooOtsControllerRXEnabled
-        cooOtsControllerTXEnabled 
+        cooOtsControllerTXEnabled
 
         - Added to cooOtsControllerAlarmState new alarm
         autoAmpliCtrlRunnig
@@ -125,7 +252,7 @@ CiscoOpticalOtsPortType ::= TEXTUAL-CONVENTION
     STATUS          current
     DESCRIPTION
         "This value indicates the port type for optical OTS
-        interface. 
+        interface.
                 Valid values are -
         line(1)      : port facing the fiber and far-end section.
         com(2)       : port facing the near-end section.
@@ -139,38 +266,64 @@ CiscoOpticalOtsPortType ::= TEXTUAL-CONVENTION
                         osc(3),
                         comCheck(4),
                         working(5),
-                        protected(6)
+                        protected(6),
+                        addDrop(7)
                     }
 
 CiscoOpticalOtsGainInDb ::= TEXTUAL-CONVENTION
     STATUS          current
     DESCRIPTION
         "OTS ports associated to amplifier device,this value represent
-        the amplifier gain setting. 
+        the amplifier gain setting.
         An integer value that represents the gain level in
-        1/100ths of dB. 
+        1/100ths of dB.
         A negative value represents not meaninful value in case the
         amplifier is switched off for any reason.
-        Example: 
+        Example:
         The value 800 represents an gain level of 8.0 dB."
     SYNTAX          Integer32 (-100..4000)
+
+CiscoOpticalOtsIEGainInDb ::= TEXTUAL-CONVENTION
+    STATUS          current
+    DESCRIPTION
+        "OTS ports associated to amplifier device,this value represent
+        the amplifier gain setting for Ingress and Egress Amplifiers.
+        An integer value that represents the gain level in
+        1/10ths of dB.
+        A negative value indicates that the amplifier
+        is switched off for any reason.
+        Example:
+        The value 80 represents an gain level of 8.0 dB."
+    SYNTAX          Integer32 (80..400)
+
 
 CiscoOpticalOtsTiltInDb ::= TEXTUAL-CONVENTION
     STATUS          current
     DESCRIPTION
         "OTS ports associated to amplifier device, this values represent
-        the tilt parameter. 
+        the tilt parameter.
         An integer value that represents the tilt level in 1/100ths of
-        dB. 
-        Example: 
+        dB.
+        Example:
         The value 300 represents a tilt level of 3.0 dB."
     SYNTAX          Integer32 (-500..500)
+
+CiscoOpticalOtsIETiltInDb ::= TEXTUAL-CONVENTION
+    STATUS          current
+    DESCRIPTION
+        "This value represents the tilt parameter for an OTS port
+         associated to the amplifier device.
+         An integer value that represents the tilt level in 1/10ths of
+         dB.
+         Example:
+         The value 30 represents a tilt level of 3.0 dB."
+    SYNTAX          Integer32 (-50..50)
 
 CiscoOpticalOtsVoaAttenInDb ::= TEXTUAL-CONVENTION
     STATUS          current
     DESCRIPTION
         "An unsigned integer value that represents the VOA attenuation
-        level in 1/100ths of dB. 
+        level in 1/100ths of dB.
         Example: The value 200 represents an attenuation
         level of 2.0 dB."
     SYNTAX          Unsigned32
@@ -182,7 +335,7 @@ CiscoOpticalOtsLaserStatus ::= TEXTUAL-CONVENTION
         Valid values are -
 
         unknown(1) : unknown status
-        on(2)      : laser on 
+        on(2)      : laser on
         off(3)     : laser off
         apr(4)     : Denotes Automatic Power Reduction (APR)"
     SYNTAX          INTEGER  {
@@ -201,10 +354,13 @@ CiscoOpticalOtsAmpliControlMode ::= TEXTUAL-CONVENTION
         manual(1) : manual control mode (An external entity has to
         provide gain/tilt settings)
         auto(2)   : automatic control mode (An internal will provide
-        gain/tilt calculation based on power setpoint)"
+        gain/tilt calculation based on power setpoint)
+        power(3)  : power control mode (An internal will provide
+        gain/tilt calculation based on power mode settings"
     SYNTAX          INTEGER  {
                         manual(1),
-                        auto(2)
+                        auto(2),
+                        power(3)
                     }
 
 CiscoOpticalOtsAmpliGainRange ::= TEXTUAL-CONVENTION
@@ -278,6 +434,19 @@ CiscoOpticalOtsState ::= TEXTUAL-CONVENTION
                         adminDown(3)
                     }
 
+CiscoOpticalOtsAdminState ::= TEXTUAL-CONVENTION
+    STATUS          current
+    DESCRIPTION
+        "This value indicates the controller status.
+        Valid values are -
+
+        up(1)        : controller admin up
+        down(2)      : controller admin down"
+    SYNTAX          INTEGER  {
+                        up(1),
+                        down(2)
+                    }
+
 CiscoOpticalOtsTranspAdminState ::= TEXTUAL-CONVENTION
     STATUS          current
     DESCRIPTION
@@ -295,6 +464,47 @@ CiscoOpticalOtsTranspAdminState ::= TEXTUAL-CONVENTION
                         maintenance(3),
                         ains(4)
                     }
+
+CiscoOpticalOts2IEGainInDb ::= TEXTUAL-CONVENTION
+    STATUS          current
+    DESCRIPTION
+        "OTS ports associated with an amplifier device. This value
+        represents the amplifier both Ingress and Egress gain setting.
+        The gain is expressed in 1/10ths of a dB.
+
+        A value of 0 indicates that the amplifier is switched off.
+
+        Example:
+          A value of 120 represents a gain level of 12.0 dB."
+    SYNTAX          Integer32 (0 | 30..400)
+
+CiscoOpticalOtsBrRatioInDb ::=TEXTUAL-CONVENTION
+    STATUS          current
+    DESCRIPTION
+        "An integer value that represents BR Ratio
+         in dB.
+        Example: The value -4500 represents a BR Ratio
+         of -45.00 dB."
+    SYNTAX          Integer32(-5000..0)
+
+CiscoOpticalOtsTemperature ::=TEXTUAL-CONVENTION
+    STATUS          current
+    DESCRIPTION
+        "An integer value that represents Temperature
+         in Celsius for OTS controllers.
+        Example: The value 4500 represents a Temperature
+            45.00 C."
+    SYNTAX          Integer32(-5000..10000)
+
+CiscoOpticalOtsVoltage ::=TEXTUAL-CONVENTION
+    STATUS          current
+    DESCRIPTION
+        "An integer value that represents Voltage
+         for OTS controller.
+        Example: The value 350 represents a Voltage
+            3.50 V."
+    SYNTAX          Integer32(-5000..10000)
+
 -- Textual Conventions definition will be defined before this line
 
 ciscoOpticalOtsMIBNotifs  OBJECT IDENTIFIER
@@ -315,7 +525,7 @@ cooOtsStatusChange NOTIFICATION-TYPE
     DESCRIPTION
         "This notification is generated when the value of
         cooOtsControllerStatus changes.
-        The varbind for this notification indicates the ifindex, 
+        The varbind for this notification indicates the ifIndex,
         ifname of the OTS interface as well as controller port type and status."
    ::= { ciscoOpticalOtsMIBNotifs 1 }
 
@@ -330,7 +540,7 @@ cooOtsOchStatusChange NOTIFICATION-TYPE
     DESCRIPTION
         "This notification is generated when the value of
         cooOtsOchControllerStatus changes.
-        The varbind for this notification indicates the ifindex, 
+        The varbind for this notification indicates the ifIndex,
         ifname of the OTS-OCH interface as well as controller port type
         and status."
    ::= { ciscoOpticalOtsMIBNotifs 2 }
@@ -370,11 +580,11 @@ cooOtsNotifEnabled OBJECT-TYPE
         cooOtsStatusChange notification is enabled. If the value of
         this object is 'false', then the generation of
         cooOtsStatusChange notification is disabled."
-    DEFVAL          { false } 
+    DEFVAL          { false }
     ::= { cooOtsController 1 }
 
 cooOtsControllerTable OBJECT-TYPE
-    SYNTAX          SEQUENCE OF CooOtsControllerEntry 
+    SYNTAX          SEQUENCE OF CooOtsControllerEntry
     MAX-ACCESS      not-accessible
     STATUS          current
     DESCRIPTION
@@ -392,7 +602,7 @@ cooOtsControllerEntry OBJECT-TYPE
         related attributes of interfaces with an ifType
         opticalTrasnport(196). Entries are created by the feature when a
         new interface is added to the ifTable."
-    INDEX           { ifIndex } 
+    INDEX           { ifIndex }
     ::= { cooOtsControllerTable 1 }
 
 CooOtsControllerEntry ::= SEQUENCE {
@@ -421,7 +631,29 @@ CooOtsControllerEntry ::= SEQUENCE {
         cooOtsControllerRXSpanLoss          CoiOpticalPower,
         cooOtsControllerTXSpanLoss          CoiOpticalPower,
         cooOtsControllerRXEnabled           TruthValue,
-        cooOtsControllerTXEnabled           TruthValue
+        cooOtsControllerTXEnabled           TruthValue,
+        cooOtsControllerIAmpliGain          CiscoOpticalOtsIEGainInDb,
+        cooOtsControllerIAmpliTilt          CiscoOpticalOtsIETiltInDb,
+        cooOtsControllerIAmpliGainRange     CiscoOpticalOtsAmpliGainRange,
+        cooOtsControllerISafetyControlMode  CiscoOpticalOtsAmpliSafetyCtrlMode,
+        cooOtsControllerIAmpliOsri          CiscoOpticalOtsOsri,
+        cooOtsControllerEAmpliGain          CiscoOpticalOtsIEGainInDb,
+        cooOtsControllerEAmpliTilt          CiscoOpticalOtsIETiltInDb,
+        cooOtsControllerEAmpliGainRange     CiscoOpticalOtsAmpliGainRange,
+        cooOtsControllerESafetyControlMode  CiscoOpticalOtsAmpliSafetyCtrlMode,
+        cooOtsControllerEAmpliOsri          CiscoOpticalOtsOsri,
+        cooOtsControllerTotLCTXPower        CoiOpticalPower,
+        cooOtsControllerTotLCRXPower        CoiOpticalPower,
+        cooOtsControllerIForceApr           INTEGER,
+        cooOtsControllerEForceApr           INTEGER,
+        cooOtsControllerBrPower             CoiOpticalPower,
+        cooOtsControllerLedState            INTEGER,
+        cooOtsControllerEAmpliBrRatio       CiscoOpticalOtsBrRatioInDb,
+        cooOtsControllerAmpliControlModeConfigVal       CiscoOpticalOtsAmpliControlMode,
+        cooOtsControllerEAmpliPowerConfigVal         CoiOpticalPower,
+        cooOtsControllerTemperature         CiscoOpticalOtsTemperature,
+        cooOtsControllerVoltage             CiscoOpticalOtsVoltage,
+        cooOtsControllerEAmpliBrPower       CoiOpticalPower
 }
 
 cooOtsControllerPortType OBJECT-TYPE
@@ -429,7 +661,7 @@ cooOtsControllerPortType OBJECT-TYPE
     MAX-ACCESS      read-only
     STATUS          current
     DESCRIPTION
-        "This object represents the port type of the optical OTS interface." 
+        "This object represents the port type of the optical OTS interface."
     ::= { cooOtsControllerEntry 1 }
 
 cooOtsControllerLaserStatus OBJECT-TYPE
@@ -438,7 +670,7 @@ cooOtsControllerLaserStatus OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the current operational state of the
-        laser." 
+        laser."
     ::= { cooOtsControllerEntry 2 }
 
 cooOtsControllerRXPower OBJECT-TYPE
@@ -448,7 +680,7 @@ cooOtsControllerRXPower OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the receive power in
-        1/100 dBm on optical OTS interfaces." 
+        1/100 dBm on optical OTS interfaces."
     ::= { cooOtsControllerEntry 3 }
 
 cooOtsControllerTXPower OBJECT-TYPE
@@ -458,7 +690,7 @@ cooOtsControllerTXPower OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the transmit power in
-        1/100 dBm on optical OTS interfaces." 
+        1/100 dBm on optical OTS interfaces."
     ::= { cooOtsControllerEntry 4 }
 
 cooOtsControllerAmpliGain OBJECT-TYPE
@@ -468,7 +700,7 @@ cooOtsControllerAmpliGain OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the amplifier gain value in
-        1/100 dB on optical OTS interfaces." 
+        1/100 dB on optical OTS interfaces."
     ::= { cooOtsControllerEntry 5 }
 
 cooOtsControllerAmpliTilt OBJECT-TYPE
@@ -478,7 +710,7 @@ cooOtsControllerAmpliTilt OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the amplifier tilt value in
-        1/100 dB on optical OTS interfaces." 
+        1/100 dB on optical OTS interfaces."
     ::= { cooOtsControllerEntry 6 }
 
 cooOtsControllerTotalRXPower OBJECT-TYPE
@@ -488,7 +720,7 @@ cooOtsControllerTotalRXPower OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object is used to represents the total receive power in
-        1/100 dBm on optical OTS interfaces." 
+        1/100 dBm on optical OTS interfaces."
     ::= { cooOtsControllerEntry 7 }
 
 cooOtsControllerTotalTXPower OBJECT-TYPE
@@ -498,7 +730,7 @@ cooOtsControllerTotalTXPower OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object is used to represents the total transmit power
-        in 1/100 dBm on optical OTS interfaces." 
+        in 1/100 dBm on optical OTS interfaces."
     ::= { cooOtsControllerEntry 8 }
 
 cooOtsControllerRXVoaAttenuation OBJECT-TYPE
@@ -508,7 +740,7 @@ cooOtsControllerRXVoaAttenuation OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the receive VOA attenuation value
-        in 1/100 dBm on optical OTS interfaces." 
+         in 1/100 dB on optical OTS interfaces."
     ::= { cooOtsControllerEntry 9 }
 
 cooOtsControllerTXVoaAttenuation OBJECT-TYPE
@@ -518,7 +750,7 @@ cooOtsControllerTXVoaAttenuation OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the transmit VOA attenuation value
-        in 1/100 dBm on optical OTS interfaces." 
+         in 1/100 dB on optical OTS interfaces."
     ::= { cooOtsControllerEntry 10 }
 
 cooOtsControllerRXLowThreshold OBJECT-TYPE
@@ -528,7 +760,7 @@ cooOtsControllerRXLowThreshold OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object is used to configure the receive low threshold in
-        1/100 dBm on optical OTS interfaces." 
+        1/100 dBm on optical OTS interfaces."
     ::= { cooOtsControllerEntry 11 }
 
 cooOtsControllerTXLowThreshold OBJECT-TYPE
@@ -538,7 +770,7 @@ cooOtsControllerTXLowThreshold OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object is used to configure the transmit low threshold in
-        1/100 dBm on optical OTS interfaces." 
+        1/100 dBm on optical OTS interfaces."
     ::= { cooOtsControllerEntry 12 }
 
 cooOtsControllerAmpliChannelPwr OBJECT-TYPE
@@ -548,7 +780,7 @@ cooOtsControllerAmpliChannelPwr OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object is used to configure the amplifier channel power in
-        1/100 dBm on optical OTS interfaces." 
+        1/100 dBm on optical OTS interfaces."
     ::= { cooOtsControllerEntry 13 }
 
 cooOtsControllerChannelPwrMaxDelta OBJECT-TYPE
@@ -558,7 +790,7 @@ cooOtsControllerChannelPwrMaxDelta OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object is used to configure the maximum delta on channel
-        power in 1/100 dBm on optical OTS interfaces." 
+        power in 1/100 dBm on optical OTS interfaces."
     ::= { cooOtsControllerEntry 14 }
 
 cooOtsControllerAmpliControlMode OBJECT-TYPE
@@ -566,7 +798,7 @@ cooOtsControllerAmpliControlMode OBJECT-TYPE
     MAX-ACCESS      read-write
     STATUS          current
     DESCRIPTION
-        "This object is used to configure the amplifier control mode." 
+        "This object is used to configure the amplifier control mode."
     ::= { cooOtsControllerEntry 15 }
 
 cooOtsControllerAmpliGainRange OBJECT-TYPE
@@ -574,7 +806,7 @@ cooOtsControllerAmpliGainRange OBJECT-TYPE
     MAX-ACCESS      read-write
     STATUS          current
     DESCRIPTION
-        "This object is used to configure the amplifier gain range." 
+        "This object is used to configure the amplifier gain range."
     ::= { cooOtsControllerEntry 16 }
 
 cooOtsControllerAmpliSafetyCtrlMode OBJECT-TYPE
@@ -582,7 +814,7 @@ cooOtsControllerAmpliSafetyCtrlMode OBJECT-TYPE
     MAX-ACCESS      read-write
     STATUS          current
     DESCRIPTION
-        "This object is used to configure the safety control mode." 
+        "This object is used to configure the safety control mode."
     ::= { cooOtsControllerEntry 17 }
 
 cooOtsControllerOsri OBJECT-TYPE
@@ -590,7 +822,7 @@ cooOtsControllerOsri OBJECT-TYPE
     MAX-ACCESS      read-write
     STATUS          current
     DESCRIPTION
-        "This object is used to configure the OSRI." 
+        "This object is used to configure the OSRI."
     ::= { cooOtsControllerEntry 18 }
 
 cooOtsControllerProtectionPortRole OBJECT-TYPE
@@ -599,7 +831,7 @@ cooOtsControllerProtectionPortRole OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the port role on
-        optical channel interfaces." 
+        optical channel interfaces."
     ::= { cooOtsControllerEntry 19 }
 
 cooOtsControllerState OBJECT-TYPE
@@ -608,7 +840,7 @@ cooOtsControllerState OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the controller status of
-        optical OTS interfaces." 
+        optical OTS interfaces."
     ::= { cooOtsControllerEntry 20 }
 
 cooOtsControllerTranspAdminState OBJECT-TYPE
@@ -617,7 +849,7 @@ cooOtsControllerTranspAdminState OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the transport administration status on
-        optical OTS interfaces." 
+        optical OTS interfaces."
     ::= { cooOtsControllerEntry 21 }
 
 cooOtsControllerAlarmState OBJECT-TYPE
@@ -667,27 +899,27 @@ cooOtsControllerAlarmState OBJECT-TYPE
         control mode
             switchToProtect : Protected port switching to active role
            autoAmpliCtrlRunning : Amplifier automatic control mode
-        algorithm running" 
+        algorithm running"
     ::= { cooOtsControllerEntry 22 }
 
 cooOtsControllerRXSpanLoss OBJECT-TYPE
     SYNTAX          CoiOpticalPower (-4000..3000)
-    UNITS           "1/100 dBm"
+    UNITS           "1/100 dB"
     MAX-ACCESS      read-only
     STATUS          current
     DESCRIPTION
-        "This object is used to represents the sapn loss power in 1/100
-        dBm on optical OTS interfaces" 
+        "This object is used to represents the span loss power in 1/100
+        dB on optical OTS interfaces"
     ::= { cooOtsControllerEntry 23 }
 
 cooOtsControllerTXSpanLoss OBJECT-TYPE
     SYNTAX          CoiOpticalPower (-4000..3000)
-    UNITS           "1/100 dBm"
+    UNITS           "1/100 dB"
     MAX-ACCESS      read-only
     STATUS          current
     DESCRIPTION
-        "This object is used to represents the sapn loss power in 1/100
-        dBm on optical OTS interfaces" 
+        "This object is used to represents the span loss power in 1/100
+        dB on optical OTS interfaces"
     ::= { cooOtsControllerEntry 24 }
 
 cooOtsControllerRXEnabled OBJECT-TYPE
@@ -696,7 +928,7 @@ cooOtsControllerRXEnabled OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the RX direction status of optical OTS
-        interfaces." 
+        interfaces."
     ::= { cooOtsControllerEntry 25 }
 
 cooOtsControllerTXEnabled OBJECT-TYPE
@@ -705,13 +937,231 @@ cooOtsControllerTXEnabled OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the TX direction status of optical OTS
-        interfaces." 
+        interfaces."
     ::= { cooOtsControllerEntry 26 }
- 
 
+cooOtsControllerIAmpliGain OBJECT-TYPE
+    SYNTAX          CiscoOpticalOtsIEGainInDb
+    UNITS           "1/10 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represents the amplifier gain value in
+        1/10 dB on optical OTS interfaces for ingress direction."
+    ::= { cooOtsControllerEntry 27 }
+
+cooOtsControllerIAmpliTilt OBJECT-TYPE
+    SYNTAX          CiscoOpticalOtsIETiltInDb
+    UNITS           "1/10 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represents the amplifier tilt value in
+        1/10 dB on optical OTS interfaces for ingress direction."
+    ::= { cooOtsControllerEntry 28 }
+
+cooOtsControllerIAmpliGainRange OBJECT-TYPE
+     SYNTAX     CiscoOpticalOtsAmpliGainRange
+     MAX-ACCESS      read-only
+     STATUS          current
+     DESCRIPTION
+        "This object is used to configure Ingress amplifier gain range."
+    ::= { cooOtsControllerEntry 29 }
+
+cooOtsControllerISafetyControlMode OBJECT-TYPE
+    SYNTAX          CiscoOpticalOtsAmpliSafetyCtrlMode
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object is used to configure Ingress safety control mode."
+    ::= { cooOtsControllerEntry 30 }
+
+cooOtsControllerIAmpliOsri OBJECT-TYPE
+     SYNTAX     CiscoOpticalOtsOsri
+     MAX-ACCESS      read-only
+     STATUS          current
+     DESCRIPTION
+        "This object is used to configure Ingress OSRI."
+     ::= { cooOtsControllerEntry 31 }
+
+cooOtsControllerEAmpliGain OBJECT-TYPE
+    SYNTAX          CiscoOpticalOtsIEGainInDb
+    UNITS           "1/10 dB"
+    MAX-ACCESS      read-write
+    STATUS          current
+    DESCRIPTION
+        "This object represents the amplifier gain value in
+        1/10 dB on optical OTS interfaces for Egress direction."
+    ::= { cooOtsControllerEntry 32 }
+
+
+cooOtsControllerEAmpliTilt OBJECT-TYPE
+    SYNTAX          CiscoOpticalOtsIETiltInDb
+    UNITS           "1/10 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represents the amplifier tilt value in
+        1/10 dB on optical OTS interfaces for egress direction."
+    ::= { cooOtsControllerEntry 33 }
+
+
+cooOtsControllerEAmpliGainRange OBJECT-TYPE
+     SYNTAX     CiscoOpticalOtsAmpliGainRange
+     MAX-ACCESS      read-only
+     STATUS          current
+     DESCRIPTION
+        "This object is used to configure the Egress amplifier gain range."
+    ::= { cooOtsControllerEntry 34 }
+
+cooOtsControllerESafetyControlMode OBJECT-TYPE
+    SYNTAX          CiscoOpticalOtsAmpliSafetyCtrlMode
+    MAX-ACCESS      read-write
+    STATUS          current
+    DESCRIPTION
+        "This object is used to configure Egress safety control mode."
+    ::= { cooOtsControllerEntry 35 }
+
+cooOtsControllerEAmpliOsri OBJECT-TYPE
+     SYNTAX     CiscoOpticalOtsOsri
+     MAX-ACCESS      read-write
+     STATUS          current
+     DESCRIPTION
+        "This object is used to configure Egress OSRI."
+     ::= { cooOtsControllerEntry 36 }
+
+cooOtsControllerTotLCTXPower OBJECT-TYPE
+     SYNTAX          CoiOpticalPower
+     UNITS           "1/100 dBm"
+     MAX-ACCESS      read-only
+     STATUS          current
+     DESCRIPTION
+        "This object represents the transmit power(C+L) in
+        1/100 dBm on optical OTS  interfaces."
+     ::= { cooOtsControllerEntry 37 }
+
+cooOtsControllerTotLCRXPower OBJECT-TYPE
+     SYNTAX          CoiOpticalPower
+     UNITS           "1/100 dBm"
+     MAX-ACCESS      read-only
+     STATUS          current
+     DESCRIPTION
+        "This object represents the receive power(C+L) in
+        1/100 dBm on optical OTS  interfaces."
+     ::= { cooOtsControllerEntry 38 }
+
+cooOtsControllerIForceApr OBJECT-TYPE
+     SYNTAX         INTEGER {
+                       off(0),
+                       on(1)
+                    }
+     MAX-ACCESS     read-only
+     STATUS         current
+     DESCRIPTION
+        "This object represents Force Automatic Power Reduction
+         for OTS interfaces."
+     ::= {cooOtsControllerEntry 39 }
+
+cooOtsControllerEForceApr OBJECT-TYPE
+     SYNTAX         INTEGER {
+                       off(0),
+                       on(1)
+                    }
+     MAX-ACCESS     read-only
+     STATUS         current
+     DESCRIPTION
+        "This object represents Force Automatic Power Reduction
+         for OTS interfaces."
+     ::= {cooOtsControllerEntry 40 }
+
+cooOtsControllerBrPower OBJECT-TYPE
+     SYNTAX          CoiOpticalPower
+     UNITS           "1/100 dBm"
+     MAX-ACCESS      read-only
+     STATUS          current
+     DESCRIPTION
+        "This object represents the BR power in
+        1/100 dBm on optical OTS  interfaces."
+     ::= { cooOtsControllerEntry 41 }
+
+cooOtsControllerLedState OBJECT-TYPE
+     SYNTAX            INTEGER {
+                             off(0),
+                             greenOn(1),
+                             greenFlashing(2),
+                             yellowOn(3),
+                             yellowFlashing(4),
+                             redOn(5),
+                             redFlashing(6),
+                             na(7)
+                      }
+     MAX-ACCESS      read-only
+     STATUS          current
+     DESCRIPTION
+        "This object represents LED state for OTS
+         interfaces."
+     ::= {cooOtsControllerEntry 42 }
+
+cooOtsControllerEAmpliBrRatio OBJECT-TYPE
+     SYNTAX        CiscoOpticalOtsBrRatioInDb
+     MAX-ACCESS    read-only
+     STATUS        current
+     DESCRIPTION
+        "This object represents EgressAmpliBrRatio for OTS
+         interfaces."
+     ::= {cooOtsControllerEntry 43 }
+
+cooOtsControllerAmpliControlModeConfigVal OBJECT-TYPE
+     SYNTAX        CiscoOpticalOtsAmpliControlMode
+     MAX-ACCESS    read-write
+     STATUS        current
+     DESCRIPTION
+        "This object represents the Configured Amplifier Control Mode Value for OTS
+         interfaces."
+     ::= {cooOtsControllerEntry 44 }
+
+cooOtsControllerEAmpliPowerConfigVal OBJECT-TYPE
+     SYNTAX          CoiOpticalPower
+     UNITS           "1/100 dBm"
+     MAX-ACCESS      read-write
+     STATUS          current
+     DESCRIPTION
+        "This object represents the Configured Egress Amplifier Power Value in
+        1/100 dBm on optical OTS  interfaces."
+     ::= { cooOtsControllerEntry 45 }
+
+cooOtsControllerTemperature OBJECT-TYPE
+     SYNTAX          CiscoOpticalOtsTemperature
+     UNITS           "1/100 C"
+     MAX-ACCESS      read-only
+     STATUS          current
+     DESCRIPTION
+        "This object represents the Controller Temperature in
+        1/100 C on optical OTS  interfaces."
+     ::= { cooOtsControllerEntry 46 }
+
+cooOtsControllerVoltage OBJECT-TYPE
+     SYNTAX          CiscoOpticalOtsVoltage
+     UNITS           "1/100 V"
+     MAX-ACCESS      read-only
+     STATUS          current
+     DESCRIPTION
+        "This object represents the Controller Temperature in
+        1/100 V on optical OTS  interfaces."
+     ::= { cooOtsControllerEntry 47 }
+
+cooOtsControllerEAmpliBrPower OBJECT-TYPE
+     SYNTAX         CoiOpticalPower
+     UNITS          "1/100 dBm"
+     MAX-ACCESS     read-only
+     STATUS         current
+     DESCRIPTION
+        "This object represents EgressAmpliBrPower for OTS
+         interfaces."
+     ::= {cooOtsControllerEntry 48 }
 
 cooOtsOchControllerTable OBJECT-TYPE
-    SYNTAX          SEQUENCE OF CooOtsOchControllerEntry 
+    SYNTAX          SEQUENCE OF CooOtsOchControllerEntry
     MAX-ACCESS      not-accessible
     STATUS          current
     DESCRIPTION
@@ -729,7 +1179,7 @@ cooOtsOchControllerEntry OBJECT-TYPE
         related attributes of interfaces with an ifType
         opticalTransport(196). Entries are created by the feature when a
         new interface is added to the ifTable."
-    INDEX           { ifIndex } 
+    INDEX           { ifIndex }
     ::= { cooOtsOchControllerTable 1 }
 
 CooOtsOchControllerEntry ::= SEQUENCE {
@@ -753,7 +1203,7 @@ cooOtsOchControllerPortType OBJECT-TYPE
     MAX-ACCESS      read-only
     STATUS          current
     DESCRIPTION
-        "This object represents the port type of the optical OTS-OCH interface." 
+        "This object represents the port type of the optical OTS-OCH interface."
     ::= { cooOtsOchControllerEntry 1 }
 
 cooOtsOchControllerLaserStatus OBJECT-TYPE
@@ -762,7 +1212,7 @@ cooOtsOchControllerLaserStatus OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the current operational state of the
-        laser." 
+        laser."
     ::= { cooOtsOchControllerEntry 2 }
 
 cooOtsOchControllerRXPower OBJECT-TYPE
@@ -772,7 +1222,7 @@ cooOtsOchControllerRXPower OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the receive power in
-        1/100 dBm on optical OTS-OCH interfaces." 
+        1/100 dBm on optical OTS-OCH interfaces."
     ::= { cooOtsOchControllerEntry 3 }
 
 cooOtsOchControllerTXPower OBJECT-TYPE
@@ -782,7 +1232,7 @@ cooOtsOchControllerTXPower OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the transmit power in
-        1/100 dBm on optical OTS-OCH interfaces." 
+        1/100 dBm on optical OTS-OCH interfaces."
     ::= { cooOtsOchControllerEntry 4 }
 
 cooOtsOchControllerRXLowThreshold OBJECT-TYPE
@@ -792,7 +1242,7 @@ cooOtsOchControllerRXLowThreshold OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object is used to configure the receive low threshold in
-        1/100 dBm on optical OTS-OCH interfaces." 
+        1/100 dBm on optical OTS-OCH interfaces."
     ::= { cooOtsOchControllerEntry 5 }
 
 cooOtsOchControllerTXLowThreshold OBJECT-TYPE
@@ -802,7 +1252,7 @@ cooOtsOchControllerTXLowThreshold OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object is used to configure the transmit low threshold in
-        1/100 dBm on optical OTS-OCH interfaces." 
+        1/100 dBm on optical OTS-OCH interfaces."
     ::= { cooOtsOchControllerEntry 6 }
 
 cooOtsOchControllerWavelength OBJECT-TYPE
@@ -813,7 +1263,7 @@ cooOtsOchControllerWavelength OBJECT-TYPE
     DESCRIPTION
         "This object represents the wavelength on
         optical OTS-OCH interfaces (unit 1/100 nm)."
-    DEFVAL          { 0 } 
+    DEFVAL          { 0 }
     ::= { cooOtsOchControllerEntry 7 }
 
 cooOtsOchControllerFrequency OBJECT-TYPE
@@ -823,7 +1273,7 @@ cooOtsOchControllerFrequency OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the frequency on
-        optical Ots-Och channel interfaces (unit 100 MHz)." 
+        optical Ots-Och channel interfaces (unit 100 MHz)."
     ::= { cooOtsOchControllerEntry 8 }
 
 cooOtsOchControllerChannelNumber OBJECT-TYPE
@@ -832,7 +1282,7 @@ cooOtsOchControllerChannelNumber OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the channel number on
-        optical OTS-OCH interfaces." 
+        optical OTS-OCH interfaces."
     ::= { cooOtsOchControllerEntry 9 }
 
 cooOtsOchControllerState OBJECT-TYPE
@@ -841,7 +1291,7 @@ cooOtsOchControllerState OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the controller status of
-        optical OTS-OCH interfaces." 
+        optical OTS-OCH interfaces."
     ::= { cooOtsOchControllerEntry 10 }
 
 cooOtsOchControllerTranspAdminState OBJECT-TYPE
@@ -850,7 +1300,7 @@ cooOtsOchControllerTranspAdminState OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the transport administration status on
-        optical OTS-OCH interfaces." 
+        optical OTS-OCH interfaces."
     ::= { cooOtsOchControllerEntry 11 }
 
 cooOtsOchControllerAlarmState OBJECT-TYPE
@@ -896,7 +1346,7 @@ cooOtsOchControllerAlarmState OBJECT-TYPE
         automatic control mode
             misAutoAmp      : Misconfiguration for amplifier automatic
         control mode
-            switchToProtect : Protected port switching to active role" 
+            switchToProtect : Protected port switching to active role"
     ::= { cooOtsOchControllerEntry 12 }
 
 cooOtsOchControllerWidth OBJECT-TYPE
@@ -907,9 +1357,9 @@ cooOtsOchControllerWidth OBJECT-TYPE
     DESCRIPTION
         "This object represents the frequency on
         optical Ots-Och channel interfaces (unit 1/10 GHz)."
-    DEFVAL          { 500 } 
+    DEFVAL          { 500 }
     ::= { cooOtsOchControllerEntry 13 }
- 
+
 
 
 cooOtsOchNotifEnabled OBJECT-TYPE
@@ -923,11 +1373,843 @@ cooOtsOchNotifEnabled OBJECT-TYPE
         cooOtsOchStatusChange notification is enabled. If the value of
         this object is 'false', then the generation of
         cooOtsOchStatusChange notification is disabled."
-    DEFVAL          { false } 
+    DEFVAL          { false }
     ::= { cooOtsController 4 }
 
+cooOtsRamanTable OBJECT-TYPE
+    SYNTAX          SEQUENCE OF CooOtsRamanEntry
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "This table provides raman information for optical layer
+        related attributes of interfaces with an ifType of
+        opticalTransport(196)."
+
+    ::= { cooOtsController 5 }
+
+cooOtsRamanEntry OBJECT-TYPE
+    SYNTAX          CooOtsRamanEntry
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "An entry containing raman information on optical layer
+        related attributes of interfaces with an ifType
+        opticalTransport(196). Entries are created by the feature
+        when a new interface is added to the ifTable."
+    INDEX           { ifIndex }
+    ::= { cooOtsRamanTable 1 }
+
+CooOtsRamanEntry ::= SEQUENCE {
+        cooOtsRaman1TXPower                 CoiOpticalPower,
+        cooOtsRaman2TXPower                 CoiOpticalPower,
+        cooOtsRaman3TXPower                 CoiOpticalPower,
+        cooOtsRaman4TXPower                 CoiOpticalPower,
+        cooOtsRaman5TXPower                 CoiOpticalPower,
+        cooOtsRaman1Wavelength              CoiOpticalWavelength,
+        cooOtsRaman2Wavelength              CoiOpticalWavelength,
+        cooOtsRaman3Wavelength              CoiOpticalWavelength,
+        cooOtsRaman4Wavelength              CoiOpticalWavelength,
+        cooOtsRaman5Wavelength              CoiOpticalWavelength,
+        cooOtsRamanCompositePower           CoiOpticalPower,
+        cooOtsRamanOsri                    CiscoOpticalOtsOsri,
+        cooOtsRamanSafetyControlMode     CiscoOpticalOtsAmpliSafetyCtrlMode,
+        cooOtsRamanForceAPR                 INTEGER,
+        cooOtsRamanBRPower                  CoiOpticalPower,
+        cooOtsRamanBRRatio                  CiscoOpticalOtsBrRatioInDb
+}
+
+cooOtsRaman1TXPower OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 mW"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represents the Power of
+         Raman Pump Instance 1 for OTS interfaces
+         (unit 1/100 mW)."
+    ::= { cooOtsRamanEntry 1 }
+
+cooOtsRaman2TXPower OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 mW"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represents the Power of
+         Raman Pump Instance 2 for OTS interfaces
+         (unit 1/100 mW)."
+    ::= { cooOtsRamanEntry 2 }
+
+cooOtsRaman3TXPower OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 mW"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represents the Power of
+         Raman Pump Instance 3 for OTS interfaces
+         (unit 1/100 mW)."
+    ::= { cooOtsRamanEntry 3 }
+
+cooOtsRaman4TXPower OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 mW"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represents the Power of
+         Raman Pump Instance 4 for OTS interfaces
+         (unit 1/100 mW)."
+    ::= { cooOtsRamanEntry 4 }
+
+cooOtsRaman5TXPower OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 mW"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represents the Power of
+         Raman Pump Instance 5 for OTS interfaces
+         (unit 1/100 mW)."
+    ::= { cooOtsRamanEntry 5 }
+
+cooOtsRaman1Wavelength OBJECT-TYPE
+    SYNTAX          CoiOpticalWavelength
+    UNITS           "1/100 nm"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represents the wavelength of
+         Raman Pump Instance 1 for OTS interfaces
+         (unit 1/100 nm)."
+
+    ::= { cooOtsRamanEntry 6 }
+
+cooOtsRaman2Wavelength OBJECT-TYPE
+    SYNTAX          CoiOpticalWavelength
+    UNITS           "1/100 nm"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represents the wavelength of
+         Raman Pump Instance 2 for OTS interfaces
+         (unit 1/100 nm)."
+    ::= { cooOtsRamanEntry 7 }
+
+cooOtsRaman3Wavelength OBJECT-TYPE
+    SYNTAX          CoiOpticalWavelength
+    UNITS           "1/100 nm"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represents the wavelength of
+         Raman Pump Instance 3 for OTS interfaces
+         (unit 1/100 nm)."
+    ::= { cooOtsRamanEntry 8 }
+
+cooOtsRaman4Wavelength OBJECT-TYPE
+    SYNTAX          CoiOpticalWavelength
+    UNITS           "1/100 nm"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represents the wavelength of
+         Raman Pump Instance 4 for OTS interfaces
+         (unit 1/100 nm)."
+    ::= { cooOtsRamanEntry 9 }
+
+cooOtsRaman5Wavelength OBJECT-TYPE
+    SYNTAX          CoiOpticalWavelength
+    UNITS           "1/100 nm"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represnts the wavelength of
+         Raman Pump Instance 5 for OTS interfaces
+         (unit 1/100 nm)."
+    ::= { cooOtsRamanEntry 10 }
+
+cooOtsRamanCompositePower OBJECT-TYPE
+      SYNTAX        CoiOpticalPower
+      UNITS           "1/100 mW"
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+          "This object represents the Composite Power
+           of Raman Pump for OTS interfaces (unit 1/100 mW)."
+      ::= { cooOtsRamanEntry 11 }
+
+cooOtsRamanOsri OBJECT-TYPE
+      SYNTAX       CiscoOpticalOtsOsri
+      MAX-ACCESS   read-only
+      STATUS       current
+      DESCRIPTION
+          "This object represents the Raman Osri
+           for OTS interfaces."
+      ::= { cooOtsRamanEntry 12 }
+
+cooOtsRamanSafetyControlMode OBJECT-TYPE
+      SYNTAX       CiscoOpticalOtsAmpliSafetyCtrlMode
+      MAX-ACCESS   read-only
+      STATUS       current
+      DESCRIPTION
+          "This object represent the Raman Safety Control
+           Mode for OTS interfaces."
+      ::= { cooOtsRamanEntry 13 }
+
+cooOtsRamanForceAPR OBJECT-TYPE
+      SYNTAX        INTEGER{
+                       off(0),
+                       on(1)
+                    }
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+          "This object represents the Raman Force APR
+           for OTS interfaces."
+      ::= { cooOtsRamanEntry 14 }
+
+cooOtsRamanBRPower OBJECT-TYPE
+      SYNTAX        CoiOpticalPower
+      UNITS           "1/100 dBm"
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+          "This object represents the Raman Br Power
+           for OTS interfaces."
+      ::= { cooOtsRamanEntry 15 }
+
+cooOtsRamanBRRatio  OBJECT-TYPE
+      SYNTAX        CiscoOpticalOtsBrRatioInDb
+      UNITS           "1/100 dB"
+      MAX-ACCESS    read-only
+      STATUS        current
+      DESCRIPTION
+          "This object represents the Raman BR Ratio
+           for OTS interfaces."
+      ::= { cooOtsRamanEntry 16 }
+
+cooOtsControllerTransceiverTable OBJECT-TYPE
+    SYNTAX          SEQUENCE OF CooOtsControllerTransceiverEntry
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "This table provides ots transceiver detail for optical layer
+        related attributes of interfaces with an ifType of
+        opticalTransport(196)."
+
+    ::= { cooOtsController 6 }
+
+cooOtsControllerTransceiverEntry OBJECT-TYPE
+    SYNTAX          CooOtsControllerTransceiverEntry
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "An entry containing ots transceiver detail on optical layer
+        related attributes of interfaces with an ifType
+        opticalTransport(196). Entries are created by the feature
+        when a new interface is added to the ifTable."
+    INDEX           { ifIndex }
+    ::= { cooOtsControllerTransceiverTable 1 }
+
+CooOtsControllerTransceiverEntry ::= SEQUENCE {
+        cooOtsControllerTransceiverVendorInfo          DisplayString
+}
+
+cooOtsControllerTransceiverVendorInfo OBJECT-TYPE
+     SYNTAX          DisplayString
+     MAX-ACCESS      read-only
+     STATUS          current
+     DESCRIPTION
+        "This object represents the Controller Vendor Information
+        on optical OTS  interfaces."
+     ::= { cooOtsControllerTransceiverEntry 1 }
+
+
+cooOtsController2Table OBJECT-TYPE
+    SYNTAX          SEQUENCE OF CooOtsController2Entry
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "This table provides management information for OTS optical layer
+        related attributes of interfaces with an ifType of
+        opticalTransport(196).
+
+        DESIGN RATIONALE:
+        This table supersedes the earlier cooOtsControllerTable which used
+        only ifIndex as the INDEX. The previous design could not distinguish
+        between LINE and COM port attributes on the same physical interface
+        (e.g., different TX power, gain settings per port). The composite
+        INDEX structure { ifIndex, cooOtsController2PortType } was introduced
+        to support multi-port OLS modules where LINE and COM ports share an
+        ifIndex but require independent operational data."
+    ::= { cooOtsController 7 }
+
+cooOtsController2Entry OBJECT-TYPE
+    SYNTAX          CooOtsController2Entry
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "An entry containing management information on OTS optical layer
+        related attributes of interfaces with an ifType
+        opticalTransport(196). Entries are created by the feature when a
+        new interface is added to the ifTable."
+    INDEX           { ifIndex, cooOtsController2PortType}
+    ::= { cooOtsController2Table 1 }
+
+CooOtsController2Entry ::= SEQUENCE {
+        cooOtsController2PortType            CiscoOpticalOtsPortType,
+        cooOtsController2LaserStatus         CiscoOpticalOtsLaserStatus,
+        cooOtsController2RXPower             CoiOpticalPower,
+        cooOtsController2TXPower             CoiOpticalPower,
+        cooOtsController2AmpliGain           CiscoOpticalOtsGainInDb,
+        cooOtsController2AmpliTilt           CiscoOpticalOtsTiltInDb,
+        cooOtsController2TotalRXPower        CoiOpticalPower,
+        cooOtsController2TotalTXPower        CoiOpticalPower,
+        cooOtsController2RXVoaAttenuation    CiscoOpticalOtsVoaAttenInDb,
+        cooOtsController2TXVoaAttenuation    CiscoOpticalOtsVoaAttenInDb,
+        cooOtsController2RXLowThreshold      CoiOpticalPower,
+        cooOtsController2TXLowThreshold      CoiOpticalPower,
+        cooOtsController2AmpliChannelPwr     CoiOpticalPower,
+        cooOtsController2ChannelPwrMaxDelta  CoiOpticalPower,
+        cooOtsController2AmpliControlMode    CiscoOpticalOtsAmpliControlMode,
+        cooOtsController2AmpliGainRange      CiscoOpticalOtsAmpliGainRange,
+        cooOtsController2AmpliSafetyCtrlMode CiscoOpticalOtsAmpliSafetyCtrlMode,
+        cooOtsController2Osri                CiscoOpticalOtsOsri,
+        cooOtsController2ProtectionPortRole  CiscoOpticalOtsProtectionPortRole,
+        cooOtsController2State               CiscoOpticalOtsAdminState,
+        cooOtsController2TranspAdminState    CiscoOpticalOtsTranspAdminState,
+        cooOtsController2AlarmState          BITS,
+        cooOtsController2RXSpanLoss          CoiOpticalPower,
+        cooOtsController2TXSpanLoss          CoiOpticalPower,
+        cooOtsController2RXEnabled           TruthValue,
+        cooOtsController2TXEnabled           TruthValue,
+        cooOtsController2IAmpliGain          CiscoOpticalOts2IEGainInDb,
+        cooOtsController2IAmpliTilt          CiscoOpticalOtsIETiltInDb,
+        cooOtsController2IAmpliGainRange     CiscoOpticalOtsAmpliGainRange,
+        cooOtsController2ISafetyControlMode  CiscoOpticalOtsAmpliSafetyCtrlMode,
+        cooOtsController2IAmpliOsri          CiscoOpticalOtsOsri,
+        cooOtsController2EAmpliGain          CiscoOpticalOts2IEGainInDb,
+        cooOtsController2EAmpliTilt          CiscoOpticalOtsIETiltInDb,
+        cooOtsController2EAmpliGainRange     CiscoOpticalOtsAmpliGainRange,
+        cooOtsController2ESafetyControlMode  CiscoOpticalOtsAmpliSafetyCtrlMode,
+        cooOtsController2EAmpliOsri          CiscoOpticalOtsOsri,
+        cooOtsController2TotLCTXPower        CoiOpticalPower,
+        cooOtsController2TotLCRXPower        CoiOpticalPower,
+        cooOtsController2IForceApr           INTEGER,
+        cooOtsController2EForceApr           INTEGER,
+        cooOtsController2BrPower             CoiOpticalPower,
+        cooOtsController2LedState            INTEGER,
+        cooOtsController2EAmpliBrRatio       CiscoOpticalOtsBrRatioInDb,
+        cooOtsController2AmpliControlModeConfigVal CiscoOpticalOtsAmpliControlMode,
+        cooOtsController2EAmpliPowerConfigVal      CoiOpticalPower,
+        cooOtsController2Temperature         CiscoOpticalOtsTemperature,
+        cooOtsController2Voltage             CiscoOpticalOtsVoltage,
+        cooOtsController2EAmpliBrPower       CoiOpticalPower
+}
+
+cooOtsController2PortType OBJECT-TYPE
+    SYNTAX          CiscoOpticalOtsPortType
+    MAX-ACCESS      not-accessible
+    STATUS          current
+    DESCRIPTION
+        "This object represents the port type of the optical OTS interface."
+    ::= { cooOtsController2Entry 1 }
+
+cooOtsController2LaserStatus OBJECT-TYPE
+    SYNTAX          CiscoOpticalOtsLaserStatus
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represents the current operational state of the
+        laser."
+    ::= { cooOtsController2Entry 2 }
+
+cooOtsController2RXPower OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 dBm"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represents the receive power in
+        1/100 dBm on optical OTS interfaces."
+    ::= { cooOtsController2Entry 3 }
+
+cooOtsController2TXPower OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 dBm"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represents the transmit power in
+        1/100 dBm on optical OTS interfaces."
+    ::= { cooOtsController2Entry 4 }
+
+cooOtsController2AmpliGain OBJECT-TYPE
+    SYNTAX          CiscoOpticalOtsGainInDb
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-write
+    STATUS          current
+    DESCRIPTION
+        "This object represents the amplifier gain value in
+        1/100 dB on optical OTS interfaces."
+    ::= { cooOtsController2Entry 5 }
+
+cooOtsController2AmpliTilt OBJECT-TYPE
+    SYNTAX          CiscoOpticalOtsTiltInDb
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-write
+    STATUS          current
+    DESCRIPTION
+        "This object represents the amplifier tilt value in
+        1/100 dB on optical OTS interfaces."
+    ::= { cooOtsController2Entry 6 }
+
+cooOtsController2TotalRXPower OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 dBm"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object is used to represents the total receive power in
+        1/100 dBm on optical OTS interfaces."
+    ::= { cooOtsController2Entry 7 }
+
+cooOtsController2TotalTXPower OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 dBm"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object is used to represents the total transmit power
+        in 1/100 dBm on optical OTS interfaces."
+    ::= { cooOtsController2Entry 8 }
+
+cooOtsController2RXVoaAttenuation OBJECT-TYPE
+    SYNTAX          CiscoOpticalOtsVoaAttenInDb
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-write
+    STATUS          current
+    DESCRIPTION
+        "This object represents the receive VOA attenuation value
+        in 1/100 dB on optical OTS interfaces."
+    ::= { cooOtsController2Entry 9 }
+
+cooOtsController2TXVoaAttenuation OBJECT-TYPE
+    SYNTAX          CiscoOpticalOtsVoaAttenInDb
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-write
+    STATUS          current
+    DESCRIPTION
+        "This object represents the transmit VOA attenuation value
+        in 1/100 dB on optical OTS interfaces."
+    ::= { cooOtsController2Entry 10 }
+
+cooOtsController2RXLowThreshold OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 dBm"
+    MAX-ACCESS      read-write
+    STATUS          current
+    DESCRIPTION
+        "This object is used to configure the receive low threshold in
+        1/100 dBm on optical OTS interfaces."
+    ::= { cooOtsController2Entry 11 }
+
+cooOtsController2TXLowThreshold OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 dBm"
+    MAX-ACCESS      read-write
+    STATUS          current
+    DESCRIPTION
+        "This object is used to configure the transmit low threshold in
+        1/100 dBm on optical OTS interfaces."
+    ::= { cooOtsController2Entry 12 }
+
+cooOtsController2AmpliChannelPwr OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 dBm"
+    MAX-ACCESS      read-write
+    STATUS          current
+    DESCRIPTION
+        "This object is used to configure the amplifier channel power in
+        1/100 dBm on optical OTS interfaces."
+    ::= { cooOtsController2Entry 13 }
+
+cooOtsController2ChannelPwrMaxDelta OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 dBm"
+    MAX-ACCESS      read-write
+    STATUS          current
+    DESCRIPTION
+        "This object is used to configure the maximum delta on channel
+        power in 1/100 dBm on optical OTS interfaces."
+    ::= { cooOtsController2Entry 14 }
+
+cooOtsController2AmpliControlMode OBJECT-TYPE
+    SYNTAX          CiscoOpticalOtsAmpliControlMode
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represents the amplifier control mode."
+    ::= { cooOtsController2Entry 15 }
+
+cooOtsController2AmpliGainRange OBJECT-TYPE
+    SYNTAX          CiscoOpticalOtsAmpliGainRange
+    MAX-ACCESS      read-write
+    STATUS          current
+    DESCRIPTION
+        "This object is used to configure the amplifier gain range."
+    ::= { cooOtsController2Entry 16 }
+
+cooOtsController2AmpliSafetyCtrlMode OBJECT-TYPE
+    SYNTAX          CiscoOpticalOtsAmpliSafetyCtrlMode
+    MAX-ACCESS      read-write
+    STATUS          current
+    DESCRIPTION
+        "This object is used to configure the safety control mode."
+    ::= { cooOtsController2Entry 17 }
+
+cooOtsController2Osri OBJECT-TYPE
+    SYNTAX          CiscoOpticalOtsOsri
+    MAX-ACCESS      read-write
+    STATUS          current
+    DESCRIPTION
+        "This object is used to configure the OSRI."
+    ::= { cooOtsController2Entry 18 }
+
+cooOtsController2ProtectionPortRole OBJECT-TYPE
+    SYNTAX          CiscoOpticalOtsProtectionPortRole
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represents the port role on
+        optical channel interfaces."
+    ::= { cooOtsController2Entry 19 }
+
+cooOtsController2State OBJECT-TYPE
+    SYNTAX          CiscoOpticalOtsAdminState
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represents the controller status of
+        optical OTS interfaces."
+    ::= { cooOtsController2Entry 20 }
+
+cooOtsController2TranspAdminState OBJECT-TYPE
+    SYNTAX          CiscoOpticalOtsTranspAdminState
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represents the transport administration status on
+        optical OTS interfaces."
+    ::= { cooOtsController2Entry 21 }
+
+cooOtsController2AlarmState OBJECT-TYPE
+    SYNTAX          BITS {
+                        noDefect(0),
+                        highRXPwr(1),
+                        highTXPwr(2),
+                        lowRXPwr(3),
+                        lowTXPwr(4),
+                        lospRXPwr(5),
+                        locRXPwr(6),
+                        degLowGain(7),
+                        degHighGain(8),
+                        alsAmp(9),
+                        aprAmp(10),
+                        noEqAutoAmp(11),
+                        misAutoAmp(12),
+                        switchToProtect(13),
+                        autoAmpliCtrlRunning(14)
+                    }
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object indicates the current alarms status of the Optics
+        layer.
+            Alarms description  :
+            noDefect        : No alarms
+            highRXPwr       : Input optical power reading over the
+        fail-high threshold
+            highTXPwr       : Output optical power reading over the
+        fail-high threshold
+            lowRXPwr        : Input optical power reading below the
+        fail-low threshold
+            lowTXPwr        : Output optical power reading below the
+        fail-low threshold
+            lospRXPwr       : Loss of optical power signal
+            locRXPwr        : Loss of optical continuity
+            degLowGain      : Amplifier gain degrade low
+            degHighGain     : Amplifier gain degrade high
+            alsAmp          : Amplifier automatic laser shutdown for
+        safety reason
+            aprAmp          : Amplifier automatic power reduction
+            noEqAutoAmp     : Channels power not equalized for
+        amplifier
+        automatic control mode
+            misAutoAmp      : Misconfiguration for amplifier automatic
+        control mode
+            switchToProtect : Protected port switching to active role
+           autoAmpliCtrlRunning : Amplifier automatic control mode
+        algorithm running"
+    ::= { cooOtsController2Entry 22 }
+
+cooOtsController2RXSpanLoss OBJECT-TYPE
+    SYNTAX          CoiOpticalPower (-4000..3000)
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object is used to represents the span loss power in 1/100
+        dB on optical OTS interfaces"
+    ::= { cooOtsController2Entry 23 }
+
+cooOtsController2TXSpanLoss OBJECT-TYPE
+    SYNTAX          CoiOpticalPower (-4000..3000)
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object is used to represents the span loss power in 1/100
+        dB on optical OTS interfaces"
+    ::= { cooOtsController2Entry 24 }
+
+cooOtsController2RXEnabled OBJECT-TYPE
+    SYNTAX          TruthValue
+    MAX-ACCESS      read-write
+    STATUS          current
+    DESCRIPTION
+        "This object represents the RX direction status of optical OTS
+        interfaces."
+    ::= { cooOtsController2Entry 25 }
+
+cooOtsController2TXEnabled OBJECT-TYPE
+    SYNTAX          TruthValue
+    MAX-ACCESS      read-write
+    STATUS          current
+    DESCRIPTION
+        "This object represents the TX direction status of optical OTS
+        interfaces."
+    ::= { cooOtsController2Entry 26 }
+
+cooOtsController2IAmpliGain OBJECT-TYPE
+    SYNTAX          CiscoOpticalOts2IEGainInDb
+    UNITS           "1/10 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represents the amplifier gain value in
+        1/10 dB on optical OTS interfaces for ingress direction."
+    ::= { cooOtsController2Entry 27 }
+
+cooOtsController2IAmpliTilt OBJECT-TYPE
+    SYNTAX          CiscoOpticalOtsIETiltInDb
+    UNITS           "1/10 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represents the amplifier tilt value in
+        1/10 dB on optical OTS interfaces for ingress direction."
+    ::= { cooOtsController2Entry 28 }
+
+cooOtsController2IAmpliGainRange OBJECT-TYPE
+     SYNTAX     CiscoOpticalOtsAmpliGainRange
+     MAX-ACCESS      read-only
+     STATUS          current
+     DESCRIPTION
+        "This object represents the Ingress amplifier gain range."
+    ::= { cooOtsController2Entry 29 }
+
+cooOtsController2ISafetyControlMode OBJECT-TYPE
+    SYNTAX          CiscoOpticalOtsAmpliSafetyCtrlMode
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represents the Ingress safety control mode."
+    ::= { cooOtsController2Entry 30 }
+
+cooOtsController2IAmpliOsri OBJECT-TYPE
+     SYNTAX     CiscoOpticalOtsOsri
+     MAX-ACCESS      read-only
+     STATUS          current
+     DESCRIPTION
+        "This object represents the Ingress OSRI."
+     ::= { cooOtsController2Entry 31 }
+
+cooOtsController2EAmpliGain OBJECT-TYPE
+    SYNTAX          CiscoOpticalOts2IEGainInDb
+    UNITS           "1/10 dB"
+    MAX-ACCESS      read-write
+    STATUS          current
+    DESCRIPTION
+        "This object represents the amplifier gain value in
+        1/10 dB on optical OTS interfaces for Egress direction."
+    ::= { cooOtsController2Entry 32 }
+
+cooOtsController2EAmpliTilt OBJECT-TYPE
+    SYNTAX          CiscoOpticalOtsIETiltInDb
+    UNITS           "1/10 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object represents the amplifier tilt value in
+        1/10 dB on optical OTS interfaces for egress direction."
+    ::= { cooOtsController2Entry 33 }
+
+cooOtsController2EAmpliGainRange OBJECT-TYPE
+     SYNTAX     CiscoOpticalOtsAmpliGainRange
+     MAX-ACCESS      read-only
+     STATUS          current
+     DESCRIPTION
+        "This object represents the Egress amplifier gain range."
+    ::= { cooOtsController2Entry 34 }
+
+cooOtsController2ESafetyControlMode OBJECT-TYPE
+    SYNTAX          CiscoOpticalOtsAmpliSafetyCtrlMode
+    MAX-ACCESS      read-write
+    STATUS          current
+    DESCRIPTION
+        "This object is used to configure Egress safety control mode."
+    ::= { cooOtsController2Entry 35 }
+
+cooOtsController2EAmpliOsri OBJECT-TYPE
+     SYNTAX     CiscoOpticalOtsOsri
+     MAX-ACCESS      read-write
+     STATUS          current
+     DESCRIPTION
+        "This object is used to configure Egress OSRI."
+     ::= { cooOtsController2Entry 36 }
+
+cooOtsController2TotLCTXPower OBJECT-TYPE
+     SYNTAX          CoiOpticalPower
+     UNITS           "1/100 dBm"
+     MAX-ACCESS      read-only
+     STATUS          current
+     DESCRIPTION
+        "This object represents the transmit power(C+L) in
+        1/100 dBm on optical OTS  interfaces."
+     ::= { cooOtsController2Entry 37 }
+
+cooOtsController2TotLCRXPower OBJECT-TYPE
+     SYNTAX          CoiOpticalPower
+     UNITS           "1/100 dBm"
+     MAX-ACCESS      read-only
+     STATUS          current
+     DESCRIPTION
+        "This object represents the receive power(C+L) in
+        1/100 dBm on optical OTS  interfaces."
+     ::= { cooOtsController2Entry 38 }
+
+cooOtsController2IForceApr OBJECT-TYPE
+     SYNTAX         INTEGER {
+                       off(0),
+                       on(1)
+                    }
+     MAX-ACCESS     read-only
+     STATUS         current
+     DESCRIPTION
+        "This object represents Force Automatic Power Reduction
+         for OTS interfaces."
+     ::= {cooOtsController2Entry 39 }
+
+cooOtsController2EForceApr OBJECT-TYPE
+     SYNTAX         INTEGER {
+                       off(0),
+                       on(1)
+                    }
+     MAX-ACCESS     read-only
+     STATUS         current
+     DESCRIPTION
+        "This object represents Force Automatic Power Reduction
+         for OTS interfaces."
+     ::= {cooOtsController2Entry 40 }
+
+cooOtsController2BrPower OBJECT-TYPE
+     SYNTAX          CoiOpticalPower
+     UNITS           "1/100 dBm"
+     MAX-ACCESS      read-only
+     STATUS          current
+     DESCRIPTION
+        "This object represents the BR power in
+        1/100 dBm on optical OTS  interfaces."
+     ::= { cooOtsController2Entry 41 }
+
+cooOtsController2LedState OBJECT-TYPE
+     SYNTAX            INTEGER {
+                             off(0),
+                             greenOn(1),
+                             greenFlashing(2),
+                             yellowOn(3),
+                             yellowFlashing(4),
+                             redOn(5),
+                             redFlashing(6),
+                             na(7)
+                      }
+     MAX-ACCESS      read-only
+     STATUS          current
+     DESCRIPTION
+        "This object represents LED state for OTS
+         interfaces."
+     ::= {cooOtsController2Entry 42 }
+
+cooOtsController2EAmpliBrRatio OBJECT-TYPE
+     SYNTAX        CiscoOpticalOtsBrRatioInDb
+     MAX-ACCESS    read-only
+     STATUS        current
+     DESCRIPTION
+        "This object represents EgressAmpliBrRatio for OTS
+         interfaces."
+     ::= {cooOtsController2Entry 43 }
+
+cooOtsController2AmpliControlModeConfigVal OBJECT-TYPE
+     SYNTAX        CiscoOpticalOtsAmpliControlMode
+     MAX-ACCESS    read-write
+     STATUS        current
+     DESCRIPTION
+        "This object represents the Configured Amplifier Control Mode Value for OTS interfaces."
+     ::= {cooOtsController2Entry 44 }
+
+cooOtsController2EAmpliPowerConfigVal OBJECT-TYPE
+     SYNTAX          CoiOpticalPower
+     UNITS           "1/100 dBm"
+     MAX-ACCESS      read-write
+     STATUS          current
+     DESCRIPTION
+        "This object represents the Configured Egress Amplifier Power Value in 1/100 dBm on optical OTS  interfaces."
+     ::= { cooOtsController2Entry 45 }
+
+cooOtsController2Temperature OBJECT-TYPE
+     SYNTAX          CiscoOpticalOtsTemperature
+     UNITS           "1/100 C"
+     MAX-ACCESS      read-only
+     STATUS          current
+     DESCRIPTION
+        "This object represents the Controller Temperature in
+        1/100 C on optical OTS  interfaces."
+     ::= { cooOtsController2Entry 46 }
+
+cooOtsController2Voltage OBJECT-TYPE
+     SYNTAX          CiscoOpticalOtsVoltage
+     UNITS           "1/100 V"
+     MAX-ACCESS      read-only
+     STATUS          current
+     DESCRIPTION
+        "This object represents the Controller Voltage in
+        1/100 V on optical OTS  interfaces."
+     ::= { cooOtsController2Entry 47 }
+
+cooOtsController2EAmpliBrPower OBJECT-TYPE
+     SYNTAX         CoiOpticalPower
+     UNITS          "1/100 dBm"
+     MAX-ACCESS     read-only
+     STATUS         current
+     DESCRIPTION
+        "This object represents EgressAmpliBrPower for OTS
+         interfaces."
+     ::= {cooOtsController2Entry 48 }
+
 cooOtsThresholdTable OBJECT-TYPE
-    SYNTAX          SEQUENCE OF CooOtsThresholdEntry 
+    SYNTAX          SEQUENCE OF CooOtsThresholdEntry
     MAX-ACCESS      not-accessible
     STATUS          current
     DESCRIPTION
@@ -949,7 +2231,7 @@ cooOtsThresholdEntry OBJECT-TYPE
     INDEX           {
                         ifIndex,
                         cooThreshIntervalType
-                    } 
+                    }
     ::= { cooOtsThresholdTable 1 }
 
 CooOtsThresholdEntry ::= SEQUENCE {
@@ -982,7 +2264,7 @@ cooThreshIntervalType OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the interval type during which the
-        performance statistics are accumulated for the interface." 
+        performance statistics are accumulated for the interface."
     ::= { cooOtsThresholdEntry 1 }
 
 cooThreshTXPowerMin OBJECT-TYPE
@@ -992,7 +2274,7 @@ cooThreshTXPowerMin OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object is used to configure the threshold of minimum
-        transmit power for the interface in 1/100 dBm." 
+        transmit power for the interface in 1/100 dBm."
     ::= { cooOtsThresholdEntry 2 }
 
 cooThreshRXPowerMin OBJECT-TYPE
@@ -1002,7 +2284,7 @@ cooThreshRXPowerMin OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object is used to configure the threshold of minimum
-        receive power for the interface in 1/100 dBm." 
+        receive power for the interface in 1/100 dBm."
     ::= { cooOtsThresholdEntry 3 }
 
 cooThreshLBCMin OBJECT-TYPE
@@ -1012,7 +2294,7 @@ cooThreshLBCMin OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object is used to configure the threshold of minimum
-        laser bias current in 1/10 percent." 
+        laser bias current in 1/10 percent."
     ::= { cooOtsThresholdEntry 4 }
 
 cooThreshTXPowerMax OBJECT-TYPE
@@ -1022,7 +2304,7 @@ cooThreshTXPowerMax OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object is used to configure the threshold of maximum
-        Transmit power for the interface in 1/100 dBm." 
+        Transmit power for the interface in 1/100 dBm."
     ::= { cooOtsThresholdEntry 5 }
 
 cooThreshRXPowerMax OBJECT-TYPE
@@ -1032,7 +2314,7 @@ cooThreshRXPowerMax OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object is used to configure the threshold of maximum
-        receive power for the interface in 1/100 dBm." 
+        receive power for the interface in 1/100 dBm."
     ::= { cooOtsThresholdEntry 6 }
 
 cooThreshLBCMax OBJECT-TYPE
@@ -1042,7 +2324,7 @@ cooThreshLBCMax OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object is used to configure the threshold of maximum
-        Laser Bias Current in 1/10 percent for the interface." 
+        Laser Bias Current in 1/10 percent for the interface."
     ::= { cooOtsThresholdEntry 7 }
 
 cooThreshTXPowerEnableMin OBJECT-TYPE
@@ -1052,7 +2334,7 @@ cooThreshTXPowerEnableMin OBJECT-TYPE
     DESCRIPTION
         "This object is used to configure the enablement of threshold
         minimum transmit power for the interface."
-    DEFVAL          { false } 
+    DEFVAL          { false }
     ::= { cooOtsThresholdEntry 8 }
 
 cooThreshRXPowerEnableMin OBJECT-TYPE
@@ -1062,7 +2344,7 @@ cooThreshRXPowerEnableMin OBJECT-TYPE
     DESCRIPTION
         "This object is used to configure the enablement of the
         threshold minimum receive power for the interface."
-    DEFVAL          { false } 
+    DEFVAL          { false }
     ::= { cooOtsThresholdEntry 9 }
 
 cooThreshLBCEnableMin OBJECT-TYPE
@@ -1072,7 +2354,7 @@ cooThreshLBCEnableMin OBJECT-TYPE
     DESCRIPTION
         "This object is used to configure the enablement of the
         threshold minimum laser bias current for the interface."
-    DEFVAL          { false } 
+    DEFVAL          { false }
     ::= { cooOtsThresholdEntry 10 }
 
 cooThreshTXPowerEnableMax OBJECT-TYPE
@@ -1082,7 +2364,7 @@ cooThreshTXPowerEnableMax OBJECT-TYPE
     DESCRIPTION
         "This object is used to configure the enablement of the
         threshold maximum transmit power for the interface."
-    DEFVAL          { false } 
+    DEFVAL          { false }
     ::= { cooOtsThresholdEntry 11 }
 
 cooThreshRXPowerEnableMax OBJECT-TYPE
@@ -1092,7 +2374,7 @@ cooThreshRXPowerEnableMax OBJECT-TYPE
     DESCRIPTION
         "This object is used to configure the enablement of the
         threshold maximum receive power for the interface."
-    DEFVAL          { false } 
+    DEFVAL          { false }
     ::= { cooOtsThresholdEntry 12 }
 
 cooThreshLBCEnableMax OBJECT-TYPE
@@ -1102,7 +2384,7 @@ cooThreshLBCEnableMax OBJECT-TYPE
     DESCRIPTION
         "This object is used to configure the enablement of the
         threshold maximum laser bias current for the interface."
-    DEFVAL          { false } 
+    DEFVAL          { false }
     ::= { cooOtsThresholdEntry 13 }
 
 cooThreshAmpliGainMin OBJECT-TYPE
@@ -1112,7 +2394,7 @@ cooThreshAmpliGainMin OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object is used to configure the threshold of minimum ampli
-        gain for the interface in 1/100 dB." 
+        gain for the interface in 1/100 dB."
     ::= { cooOtsThresholdEntry 14 }
 
 cooThreshAmpliGainMax OBJECT-TYPE
@@ -1122,7 +2404,7 @@ cooThreshAmpliGainMax OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object is used to configure the threshold of maximum ampli
-        gain for the interface in 1/100 dB." 
+        gain for the interface in 1/100 dB."
     ::= { cooOtsThresholdEntry 15 }
 
 cooThreshAmpliGainEnableMax OBJECT-TYPE
@@ -1132,7 +2414,7 @@ cooThreshAmpliGainEnableMax OBJECT-TYPE
     DESCRIPTION
         "This object is used to configure the enablement of the
         threshold maximum ampli gain for the interface."
-    DEFVAL          { false } 
+    DEFVAL          { false }
     ::= { cooOtsThresholdEntry 16 }
 
 cooThreshAmpliGainEnableMin OBJECT-TYPE
@@ -1142,7 +2424,7 @@ cooThreshAmpliGainEnableMin OBJECT-TYPE
     DESCRIPTION
         "This object is used to configure the enablement of the
         threshold minimum ampli gain for the interface."
-    DEFVAL          { false } 
+    DEFVAL          { false }
     ::= { cooOtsThresholdEntry 17 }
 
 cooThreshAmpliGainTiltMin OBJECT-TYPE
@@ -1152,7 +2434,7 @@ cooThreshAmpliGainTiltMin OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object is used to configure the threshold of minimum ampli
-        gain tilt for the interface in 1/100 dB." 
+        gain tilt for the interface in 1/100 dB."
     ::= { cooOtsThresholdEntry 18 }
 
 cooThreshAmpliGainTiltMax OBJECT-TYPE
@@ -1162,7 +2444,7 @@ cooThreshAmpliGainTiltMax OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object is used to configure the threshold of maximum ampli
-        gain tilt for the interface in 1/100 dB." 
+        gain tilt for the interface in 1/100 dB."
     ::= { cooOtsThresholdEntry 19 }
 
 cooThreshAmpliGainTiltEnableMax OBJECT-TYPE
@@ -1172,7 +2454,7 @@ cooThreshAmpliGainTiltEnableMax OBJECT-TYPE
     DESCRIPTION
         "This object is used to configure the enablement of the
         threshold maximum ampli gain tilt for the interface."
-    DEFVAL          { false } 
+    DEFVAL          { false }
     ::= { cooOtsThresholdEntry 20 }
 
 cooThreshAmpliGainTiltEnableMin OBJECT-TYPE
@@ -1182,13 +2464,13 @@ cooThreshAmpliGainTiltEnableMin OBJECT-TYPE
     DESCRIPTION
         "This object is used to configure the enablement of the
         threshold minimum ampli gain tilt for the interface."
-    DEFVAL          { false } 
+    DEFVAL          { false }
     ::= { cooOtsThresholdEntry 21 }
- 
+
 
 
 cooOtsCurrentTable OBJECT-TYPE
-    SYNTAX          SEQUENCE OF CooOtsCurrentEntry 
+    SYNTAX          SEQUENCE OF CooOtsCurrentEntry
     MAX-ACCESS      not-accessible
     STATUS          current
     DESCRIPTION
@@ -1210,7 +2492,7 @@ cooOtsCurrentEntry OBJECT-TYPE
     INDEX           {
                         ifIndex,
                         cooCurrentIntervalType
-                    } 
+                    }
     ::= { cooOtsCurrentTable 1 }
 
 CooOtsCurrentEntry ::= SEQUENCE {
@@ -1230,7 +2512,25 @@ CooOtsCurrentEntry ::= SEQUENCE {
         cooCurrentAmpliGainAvg     Integer32,
         cooCurrentAmpliGainTiltMin Integer32,
         cooCurrentAmpliGainTiltMax Integer32,
-        cooCurrentAmpliGainTiltAvg Integer32
+        cooCurrentAmpliGainTiltAvg Integer32,
+        cooCurrentTXPowerCLMin     CoiOpticalPower,
+        cooCurrentTXPowerCLMax     CoiOpticalPower,
+        cooCurrentTXPowerCLAvg     CoiOpticalPower,
+        cooCurrentRXPowerCLMin     CoiOpticalPower,
+        cooCurrentRXPowerCLMax     CoiOpticalPower,
+        cooCurrentRXPowerCLAvg     CoiOpticalPower,
+        cooCurrentIAmpliGainMin     Integer32,
+        cooCurrentIAmpliGainMax     Integer32,
+        cooCurrentIAmpliGainAvg     Integer32,
+        cooCurrentEAmpliGainMin     Integer32,
+        cooCurrentEAmpliGainMax     Integer32,
+        cooCurrentEAmpliGainAvg     Integer32,
+        cooCurrentIAmpliGainTiltMin Integer32,
+        cooCurrentIAmpliGainTiltMax Integer32,
+        cooCurrentIAmpliGainTiltAvg Integer32,
+        cooCurrentEAmpliGainTiltMin Integer32,
+        cooCurrentEAmpliGainTiltMax Integer32,
+        cooCurrentEAmpliGainTiltAvg Integer32
 }
 
 cooCurrentIntervalType OBJECT-TYPE
@@ -1239,7 +2539,7 @@ cooCurrentIntervalType OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the interval type during which the
-        current performance statistics are accumulated." 
+        current performance statistics are accumulated."
     ::= { cooOtsCurrentEntry 1 }
 
 cooCurrentTXPowerMax OBJECT-TYPE
@@ -1249,7 +2549,7 @@ cooCurrentTXPowerMax OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the current maximum transmit power
-        for the interface in 1/100 dBm." 
+        for the interface in 1/100 dBm."
     ::= { cooOtsCurrentEntry 2 }
 
 cooCurrentRXPowerMax OBJECT-TYPE
@@ -1259,7 +2559,7 @@ cooCurrentRXPowerMax OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the current maximum receive power for the
-        interface in 1/100 dBm." 
+        interface in 1/100 dBm."
     ::= { cooOtsCurrentEntry 3 }
 
 cooCurrentLBCMax OBJECT-TYPE
@@ -1269,7 +2569,7 @@ cooCurrentLBCMax OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the current maximum laser bias current in
-        1/10 percent for the interface." 
+        1/10 percent for the interface."
     ::= { cooOtsCurrentEntry 4 }
 
 cooCurrentTXPowerMin OBJECT-TYPE
@@ -1280,7 +2580,7 @@ cooCurrentTXPowerMin OBJECT-TYPE
     DESCRIPTION
         "This object specifies the current minimum transmit power for
         the
-        interface in 1/100 dBm." 
+        interface in 1/100 dBm."
     ::= { cooOtsCurrentEntry 5 }
 
 cooCurrentRXPowerMin OBJECT-TYPE
@@ -1290,7 +2590,7 @@ cooCurrentRXPowerMin OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the current minimum receive power for the
-        interface in 1/100 dBm." 
+        interface in 1/100 dBm."
     ::= { cooOtsCurrentEntry 6 }
 
 cooCurrentLBCMin OBJECT-TYPE
@@ -1300,7 +2600,7 @@ cooCurrentLBCMin OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the current minimum laser bias current in
-        1/10 percent for the interface." 
+        1/10 percent for the interface."
     ::= { cooOtsCurrentEntry 7 }
 
 cooCurrentTXPowerAvg OBJECT-TYPE
@@ -1310,7 +2610,7 @@ cooCurrentTXPowerAvg OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the current average transmit power
-        for the interface in 1/100 dBm." 
+        for the interface in 1/100 dBm."
     ::= { cooOtsCurrentEntry 8 }
 
 cooCurrentRXPowerAvg OBJECT-TYPE
@@ -1320,7 +2620,7 @@ cooCurrentRXPowerAvg OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the current average receive power
-        for the interface in 1/100 dBm." 
+        for the interface in 1/100 dBm."
     ::= { cooOtsCurrentEntry 9 }
 
 cooCurrentLBCAvg OBJECT-TYPE
@@ -1330,7 +2630,7 @@ cooCurrentLBCAvg OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the current average Laser Bias Current
-        in 1/10 percent for the interface." 
+        in 1/10 percent for the interface."
     ::= { cooOtsCurrentEntry 10 }
 
 cooCurrentTimestamp OBJECT-TYPE
@@ -1339,7 +2639,7 @@ cooCurrentTimestamp OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the timestamp for
-        the current bucket for the interface." 
+        the current bucket for the interface."
     ::= { cooOtsCurrentEntry 11 }
 
 cooCurrentAmpliGainMin OBJECT-TYPE
@@ -1350,7 +2650,7 @@ cooCurrentAmpliGainMin OBJECT-TYPE
     DESCRIPTION
         "This object specifies the current minimum amplifier gain for
         the
-        interface in 1/100 dB." 
+        interface in 1/100 dB."
     ::= { cooOtsCurrentEntry 12 }
 
 cooCurrentAmpliGainMax OBJECT-TYPE
@@ -1361,7 +2661,7 @@ cooCurrentAmpliGainMax OBJECT-TYPE
     DESCRIPTION
         "This object specifies the current maximum amplifier gain for
         the
-        interface in 1/100 dB." 
+        interface in 1/100 dB."
     ::= { cooOtsCurrentEntry 13 }
 
 cooCurrentAmpliGainAvg OBJECT-TYPE
@@ -1371,7 +2671,7 @@ cooCurrentAmpliGainAvg OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the current average amplifier gain for
-        the interface in 1/100 dB." 
+        the interface in 1/100 dB."
     ::= { cooOtsCurrentEntry 14 }
 
 cooCurrentAmpliGainTiltMin OBJECT-TYPE
@@ -1382,7 +2682,7 @@ cooCurrentAmpliGainTiltMin OBJECT-TYPE
     DESCRIPTION
         "This object specifies the current minimum amplifier gain tilt
         for
-        the interface in 1/100 dB." 
+        the interface in 1/100 dB."
     ::= { cooOtsCurrentEntry 15 }
 
 cooCurrentAmpliGainTiltMax OBJECT-TYPE
@@ -1393,7 +2693,7 @@ cooCurrentAmpliGainTiltMax OBJECT-TYPE
     DESCRIPTION
         "This object specifies the current maximum amplifier gain tilt
         for
-        the interface in 1/100 dB." 
+        the interface in 1/100 dB."
     ::= { cooOtsCurrentEntry 16 }
 
 cooCurrentAmpliGainTiltAvg OBJECT-TYPE
@@ -1404,13 +2704,203 @@ cooCurrentAmpliGainTiltAvg OBJECT-TYPE
     DESCRIPTION
         "This object specifies the current average amplifier gain tilt
         for
-        the interface in 1/100 dB." 
+        the interface in 1/100 dB."
     ::= { cooOtsCurrentEntry 17 }
- 
 
+cooCurrentTXPowerCLMin OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 dBm"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the current minimum transmit power C+L
+        for the interface in 1/100 dBm."
+    ::= { cooOtsCurrentEntry 18 }
+
+cooCurrentTXPowerCLMax OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 dBm"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the current maximum transmit power C+L
+        for the interface in 1/100 dBm."
+    ::= { cooOtsCurrentEntry 19 }
+
+cooCurrentTXPowerCLAvg OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 dBm"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the current Average transmit power C+L
+        for the interface in 1/100 dBm."
+    ::= { cooOtsCurrentEntry 20 }
+
+cooCurrentRXPowerCLMin OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 dBm"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the current minimum receive power
+        for the interface in 1/100 dBm."
+    ::= { cooOtsCurrentEntry 21 }
+
+cooCurrentRXPowerCLMax OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 dBm"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the current maximun receive power
+        for the interface in 1/100 dBm."
+    ::= { cooOtsCurrentEntry 22 }
+
+cooCurrentRXPowerCLAvg OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 dBm"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the current average receive power
+        for the interface in 1/100 dBm."
+    ::= { cooOtsCurrentEntry 23 }
+
+cooCurrentIAmpliGainMin OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the current minimum ingress amplifier gain for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsCurrentEntry 24 }
+
+cooCurrentIAmpliGainMax OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the current maximum ingress amplifier gain for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsCurrentEntry 25 }
+
+cooCurrentIAmpliGainAvg OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the current average ingress amplifier gain for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsCurrentEntry 26 }
+
+cooCurrentEAmpliGainMin OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the current minimum egress amplifier gain for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsCurrentEntry 27 }
+
+cooCurrentEAmpliGainMax OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the current maximum egress amplifier gain for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsCurrentEntry 28 }
+
+cooCurrentEAmpliGainAvg OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the current average egress amplifier gain for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsCurrentEntry 29 }
+
+cooCurrentIAmpliGainTiltMin OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the current minimum ingress amplifier gain tilt for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsCurrentEntry 30 }
+
+cooCurrentIAmpliGainTiltMax OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the current maximum ingress amplifier gain tilt for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsCurrentEntry 31 }
+
+cooCurrentIAmpliGainTiltAvg OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the current average ingress amplifier gain tilt for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsCurrentEntry 32 }
+
+cooCurrentEAmpliGainTiltMin OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the current minimum egress amplifier gain tilt for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsCurrentEntry 33 }
+
+cooCurrentEAmpliGainTiltMax OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the current maximum egress amplifier gain tilt for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsCurrentEntry 34 }
+
+cooCurrentEAmpliGainTiltAvg OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the current average egress amplifier gain tilt for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsCurrentEntry 35 }
 
 cooOtsIntervalTable OBJECT-TYPE
-    SYNTAX          SEQUENCE OF CooOtsIntervalEntry 
+    SYNTAX          SEQUENCE OF CooOtsIntervalEntry
     MAX-ACCESS      not-accessible
     STATUS          current
     DESCRIPTION
@@ -1434,7 +2924,7 @@ cooOtsIntervalEntry OBJECT-TYPE
                         ifIndex,
                         cooIntervalType,
                         cooIntervalNum
-                    } 
+                    }
     ::= { cooOtsIntervalTable 1 }
 
 CooOtsIntervalEntry ::= SEQUENCE {
@@ -1455,7 +2945,25 @@ CooOtsIntervalEntry ::= SEQUENCE {
         cooIntervalAmpliGainAvg     Integer32,
         cooIntervalAmpliGainTiltMin Integer32,
         cooIntervalAmpliGainTiltMax Integer32,
-        cooIntervalAmpliGainTiltAvg Integer32
+        cooIntervalAmpliGainTiltAvg Integer32,
+        cooIntervalTXPowerCLMin     CoiOpticalPower,
+        cooIntervalTXPowerCLMax     CoiOpticalPower,
+        cooIntervalTXPowerCLAvg     CoiOpticalPower,
+        cooIntervalRXPowerCLMin     CoiOpticalPower,
+        cooIntervalRXPowerCLMax     CoiOpticalPower,
+        cooIntervalRXPowerCLAvg     CoiOpticalPower,
+        cooIntervalIAmpliGainMin     Integer32,
+        cooIntervalIAmpliGainMax     Integer32,
+        cooIntervalIAmpliGainAvg     Integer32,
+        cooIntervalEAmpliGainMin     Integer32,
+        cooIntervalEAmpliGainMax     Integer32,
+        cooIntervalEAmpliGainAvg     Integer32,
+        cooIntervalIAmpliGainTiltMin Integer32,
+        cooIntervalIAmpliGainTiltMax Integer32,
+        cooIntervalIAmpliGainTiltAvg Integer32,
+        cooIntervalEAmpliGainTiltMin Integer32,
+        cooIntervalEAmpliGainTiltMax Integer32,
+        cooIntervalEAmpliGainTiltAvg Integer32
 }
 
 cooIntervalType OBJECT-TYPE
@@ -1464,7 +2972,7 @@ cooIntervalType OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the interval type during which the
-        performance statistics are accumulated." 
+        performance statistics are accumulated."
     ::= { cooOtsIntervalEntry 1 }
 
 cooIntervalNum OBJECT-TYPE
@@ -1476,7 +2984,7 @@ cooIntervalNum OBJECT-TYPE
         interval performance values is available.
         The interval identified by 1 is the most recent 15 minute
         or 24 hour interval, and the interval identified by N is
-        the interval immediately preceding the one identified by N-1." 
+        the interval immediately preceding the one identified by N-1."
     ::= { cooOtsIntervalEntry 2 }
 
 cooIntervalTXPowerMax OBJECT-TYPE
@@ -1486,7 +2994,7 @@ cooIntervalTXPowerMax OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the interval maximum transmit power in
-        1/100 dBm for the interface." 
+        1/100 dBm for the interface."
     ::= { cooOtsIntervalEntry 3 }
 
 cooIntervalRXPowerMax OBJECT-TYPE
@@ -1496,7 +3004,7 @@ cooIntervalRXPowerMax OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the interval maximum receive power in
-        1/100 dBm for the interface." 
+        1/100 dBm for the interface."
     ::= { cooOtsIntervalEntry 4 }
 
 cooIntervalLBCMax OBJECT-TYPE
@@ -1506,7 +3014,7 @@ cooIntervalLBCMax OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the interval maximum laser bias current
-        in 1/10 percent for the interface." 
+        in 1/10 percent for the interface."
     ::= { cooOtsIntervalEntry 5 }
 
 cooIntervalTXPowerMin OBJECT-TYPE
@@ -1516,7 +3024,7 @@ cooIntervalTXPowerMin OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the interval minimum transmit power in
-        1/100 dBm for the interface." 
+        1/100 dBm for the interface."
     ::= { cooOtsIntervalEntry 6 }
 
 cooIntervalRXPowerMin OBJECT-TYPE
@@ -1526,7 +3034,7 @@ cooIntervalRXPowerMin OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the interval minimum receive power in
-        1/100 dBm for the interface." 
+        1/100 dBm for the interface."
     ::= { cooOtsIntervalEntry 7 }
 
 cooIntervalLBCMin OBJECT-TYPE
@@ -1536,7 +3044,7 @@ cooIntervalLBCMin OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the interval minimum laser bias current
-        in 1/10 percent for the interface." 
+        in 1/10 percent for the interface."
     ::= { cooOtsIntervalEntry 8 }
 
 cooIntervalTXPowerAvg OBJECT-TYPE
@@ -1546,7 +3054,7 @@ cooIntervalTXPowerAvg OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the interval average transmit power in
-        1/100 dBm for the interface." 
+        1/100 dBm for the interface."
     ::= { cooOtsIntervalEntry 9 }
 
 cooIntervalRXPowerAvg OBJECT-TYPE
@@ -1556,7 +3064,7 @@ cooIntervalRXPowerAvg OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the interval average receive power in
-        1/100 dBm for the interface." 
+        1/100 dBm for the interface."
     ::= { cooOtsIntervalEntry 10 }
 
 cooIntervalLBCAvg OBJECT-TYPE
@@ -1566,7 +3074,7 @@ cooIntervalLBCAvg OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the interval average laser bias current
-        in 1/10 percent for the interface." 
+        in 1/10 percent for the interface."
     ::= { cooOtsIntervalEntry 11 }
 
 cooIntervalTimestamp OBJECT-TYPE
@@ -1575,7 +3083,7 @@ cooIntervalTimestamp OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the timestamp, for the bucket specified
-        by 'cooIntervalNum', for the interface." 
+        by 'cooIntervalNum', for the interface."
     ::= { cooOtsIntervalEntry 12 }
 
 cooIntervalAmpliGainMin OBJECT-TYPE
@@ -1585,7 +3093,7 @@ cooIntervalAmpliGainMin OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the interval minimum amplifier gain in
-        1/100 dB for the interface." 
+        1/100 dB for the interface."
     ::= { cooOtsIntervalEntry 13 }
 
 cooIntervalAmpliGainMax OBJECT-TYPE
@@ -1595,7 +3103,7 @@ cooIntervalAmpliGainMax OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the interval maximum amplifier gain in
-        1/100 dB for the interface." 
+        1/100 dB for the interface."
     ::= { cooOtsIntervalEntry 14 }
 
 cooIntervalAmpliGainAvg OBJECT-TYPE
@@ -1604,7 +3112,7 @@ cooIntervalAmpliGainAvg OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the interval acerage amplifier gain in
-        1/100 dB for the interface." 
+        1/100 dB for the interface."
     ::= { cooOtsIntervalEntry 15 }
 
 cooIntervalAmpliGainTiltMin OBJECT-TYPE
@@ -1614,7 +3122,7 @@ cooIntervalAmpliGainTiltMin OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the interval minimum amplifier gain tilt
-        in 1/100 dB for the interface." 
+        in 1/100 dB for the interface."
     ::= { cooOtsIntervalEntry 16 }
 
 cooIntervalAmpliGainTiltMax OBJECT-TYPE
@@ -1624,7 +3132,7 @@ cooIntervalAmpliGainTiltMax OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the interval maximum amplifier gain tilt
-        in 1/100 dB for the interface." 
+        in 1/100 dB for the interface."
     ::= { cooOtsIntervalEntry 17 }
 
 cooIntervalAmpliGainTiltAvg OBJECT-TYPE
@@ -1634,9 +3142,201 @@ cooIntervalAmpliGainTiltAvg OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the interval average amplifier gain tilt
-        in 1/100 dB for the interface." 
+        in 1/100 dB for the interface."
     ::= { cooOtsIntervalEntry 18 }
- 
+
+cooIntervalTXPowerCLMin OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 dBm"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the interval minimum transmit power C+L
+        for the interface in 1/100 dBm."
+    ::= { cooOtsIntervalEntry 19 }
+
+cooIntervalTXPowerCLMax OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 dBm"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the interval maximum transmit power C+L
+        for the interface in 1/100 dBm."
+    ::= { cooOtsIntervalEntry 20 }
+
+cooIntervalTXPowerCLAvg OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 dBm"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the interval Average transmit power C+L
+        for the interface in 1/100 dBm."
+    ::= { cooOtsIntervalEntry 21 }
+
+cooIntervalRXPowerCLMin OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 dBm"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the interval minimum receive power
+        for the interface in 1/100 dBm."
+    ::= { cooOtsIntervalEntry 22 }
+
+cooIntervalRXPowerCLMax OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 dBm"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the interval maximun receive power
+        for the interface in 1/100 dBm."
+    ::= { cooOtsIntervalEntry 23 }
+
+cooIntervalRXPowerCLAvg OBJECT-TYPE
+    SYNTAX          CoiOpticalPower
+    UNITS           "1/100 dBm"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the interval average receive power
+        for the interface in 1/100 dBm."
+    ::= { cooOtsIntervalEntry 24 }
+
+cooIntervalIAmpliGainMin OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the interval minimum ingress amplifier gain for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsIntervalEntry 25 }
+
+cooIntervalIAmpliGainMax OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the interval maximum ingress amplifier gain for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsIntervalEntry 26 }
+
+cooIntervalIAmpliGainAvg OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the interval average ingress amplifier gain for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsIntervalEntry 27 }
+
+cooIntervalEAmpliGainMin OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the interval minimum egress amplifier gain for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsIntervalEntry 28 }
+
+cooIntervalEAmpliGainMax OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the interval maximum egress amplifier gain for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsIntervalEntry 29 }
+
+cooIntervalEAmpliGainAvg OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the interval average egress amplifier gain for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsIntervalEntry 30 }
+
+cooIntervalIAmpliGainTiltMin OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the interval minimum ingress amplifier gain tilt for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsIntervalEntry 31 }
+
+cooIntervalIAmpliGainTiltMax OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the interval maximum ingress amplifier gain tilt for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsIntervalEntry 32 }
+
+cooIntervalIAmpliGainTiltAvg OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the interval average ingress amplifier gain tilt for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsIntervalEntry 33 }
+
+cooIntervalEAmpliGainTiltMin OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the interval minimum egress amplifier gain tilt for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsIntervalEntry 34 }
+
+cooIntervalEAmpliGainTiltMax OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the interval maximum egress amplifier gain tilt for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsIntervalEntry 35 }
+
+cooIntervalEAmpliGainTiltAvg OBJECT-TYPE
+    SYNTAX          Integer32
+    UNITS           "1/100 dB"
+    MAX-ACCESS      read-only
+    STATUS          current
+    DESCRIPTION
+        "This object specifies the interval average egress amplifier gain tilt for
+        the
+        interface in 1/100 dB."
+    ::= { cooOtsIntervalEntry 36 }
+
 
 cooOtsEquipmentAlarmGroup  OBJECT IDENTIFIER
     ::= { ciscoOpticalOtsMIBObjects 5 }
@@ -1648,7 +3348,7 @@ cooOtsAlarmLocation OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object indicates the location of the component that
-        raised alarm, within the device." 
+        raised alarm, within the device."
     ::= { cooOtsEquipmentAlarmGroup 1 }
 
 cooOtsAlarmType OBJECT-TYPE
@@ -1656,7 +3356,7 @@ cooOtsAlarmType OBJECT-TYPE
     MAX-ACCESS      accessible-for-notify
     STATUS          current
     DESCRIPTION
-        "This object indicates the type of alarm that is raised." 
+        "This object indicates the type of alarm that is raised."
     ::= { cooOtsEquipmentAlarmGroup 2 }
 
 cooOtsAlarmTimeStamp OBJECT-TYPE
@@ -1665,7 +3365,7 @@ cooOtsAlarmTimeStamp OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the time when an event occurred. This is
-        accurate only upto a second." 
+        accurate only upto a second."
     ::= { cooOtsEquipmentAlarmGroup 3 }
 
 cooOtsAlarmName OBJECT-TYPE
@@ -1674,7 +3374,7 @@ cooOtsAlarmName OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object represents the user-visible name, which
-        uniquely identifies the alarm in the system." 
+        uniquely identifies the alarm in the system."
     ::= { cooOtsEquipmentAlarmGroup 4 }
 
 cooOtsAlarmAdditionalInfo OBJECT-TYPE
@@ -1684,7 +3384,7 @@ cooOtsAlarmAdditionalInfo OBJECT-TYPE
     DESCRIPTION
         "This object provides additional information about the alarm.
         This object would be an empty string if no additional
-        information is specified." 
+        information is specified."
     ::= { cooOtsEquipmentAlarmGroup 5 }
 
 cooOtsAlarmSeverity OBJECT-TYPE
@@ -1692,7 +3392,7 @@ cooOtsAlarmSeverity OBJECT-TYPE
     MAX-ACCESS      accessible-for-notify
     STATUS          current
     DESCRIPTION
-        "This object specifies alarm severity." 
+        "This object specifies alarm severity."
     ::= { cooOtsEquipmentAlarmGroup 6 }
 
 cooOtsAlarmStatus OBJECT-TYPE
@@ -1700,7 +3400,7 @@ cooOtsAlarmStatus OBJECT-TYPE
     MAX-ACCESS      accessible-for-notify
     STATUS          current
     DESCRIPTION
-        "This object specifies alarm status." 
+        "This object specifies alarm status."
     ::= { cooOtsEquipmentAlarmGroup 7 }
 
 cooOtsAlarmServiceAffecting OBJECT-TYPE
@@ -1709,7 +3409,7 @@ cooOtsAlarmServiceAffecting OBJECT-TYPE
     STATUS          current
     DESCRIPTION
         "This object specifies the service affecting state of the
-        alarm." 
+        alarm."
     ::= { cooOtsEquipmentAlarmGroup 8 }
 -- MIB Conformance Statements
 
@@ -1742,6 +3442,13 @@ ciscoOpticalOtsMIBCompliance MODULE-COMPLIANCE
         "The collection of objects to allow configurations and give
         information related to the optical layer characteristics
         for interfaces of ifType opticalChannel(196)."
+
+    GROUP           cooOtsController2Group
+    DESCRIPTION
+        "The collection of objects to allow configurations and give
+        information related to the optical OTS characteristics
+        for interfaces of ifType opticalTransport(196) using the
+        controller2 table."
 
     GROUP           cooOtsOchControllerGroup
     DESCRIPTION
@@ -1874,7 +3581,29 @@ cooOtsGroup OBJECT-GROUP
                         cooIntervalAmpliGainAvg,
                         cooIntervalAmpliGainTiltMin,
                         cooIntervalAmpliGainTiltMax,
-                        cooIntervalAmpliGainTiltAvg
+                        cooIntervalAmpliGainTiltAvg,
+                        cooOtsControllerIAmpliGain,
+                        cooOtsControllerIAmpliTilt,
+                        cooOtsControllerIAmpliGainRange,
+                        cooOtsControllerISafetyControlMode,
+                        cooOtsControllerIAmpliOsri,
+                        cooOtsControllerEAmpliGain,
+                        cooOtsControllerEAmpliTilt,
+                        cooOtsControllerEAmpliGainRange,
+                        cooOtsControllerESafetyControlMode,
+                        cooOtsControllerEAmpliOsri,
+                        cooOtsControllerTotLCTXPower,
+                        cooOtsControllerTotLCRXPower,
+                        cooOtsControllerIForceApr,
+                        cooOtsControllerEForceApr,
+                        cooOtsControllerBrPower,
+                        cooOtsControllerLedState,
+                        cooOtsControllerEAmpliBrRatio,
+                        cooOtsControllerAmpliControlModeConfigVal,
+                        cooOtsControllerEAmpliPowerConfigVal,
+                        cooOtsControllerTemperature,
+                        cooOtsControllerVoltage,
+                        cooOtsControllerTransceiverVendorInfo
                     }
     STATUS          current
     DESCRIPTION
@@ -1945,7 +3674,28 @@ cooOtsControllerGroup OBJECT-GROUP
                         cooOtsControllerAmpliSafetyCtrlMode,
                         cooOtsControllerOsri,
                         cooOtsControllerRXEnabled,
-                        cooOtsControllerTXEnabled
+                        cooOtsControllerTXEnabled,
+                        cooOtsControllerIAmpliGain,
+                        cooOtsControllerIAmpliTilt,
+                        cooOtsControllerIAmpliGainRange,
+                        cooOtsControllerISafetyControlMode,
+                        cooOtsControllerIAmpliOsri,
+                        cooOtsControllerEAmpliGain,
+                        cooOtsControllerEAmpliTilt,
+                        cooOtsControllerEAmpliGainRange,
+                        cooOtsControllerESafetyControlMode,
+                        cooOtsControllerEAmpliOsri,
+                        cooOtsControllerTotLCTXPower,
+                        cooOtsControllerTotLCRXPower,
+                        cooOtsControllerIForceApr,
+                        cooOtsControllerEForceApr,
+                        cooOtsControllerBrPower,
+                        cooOtsControllerLedState,
+                        cooOtsControllerEAmpliBrRatio,
+                        cooOtsControllerAmpliControlModeConfigVal,
+                        cooOtsControllerEAmpliPowerConfigVal,
+                        cooOtsControllerTemperature,
+                        cooOtsControllerVoltage
                     }
     STATUS          current
     DESCRIPTION
@@ -2119,6 +3869,42 @@ cooOtsOchNotifEnableGroup OBJECT-GROUP
         OTS-OCH layer."
     ::= { ciscoOpticalOtsMIBGroups 13 }
 
+cooOtsController2Group OBJECT-GROUP
+    OBJECTS         {
+                        cooOtsController2RXPower,
+                        cooOtsController2TXPower,
+                        cooOtsController2TotalTXPower,
+                        cooOtsController2State,
+                        cooOtsController2EAmpliGain,
+                        cooOtsController2ESafetyControlMode,
+                        cooOtsController2EAmpliOsri,
+                        cooOtsController2EForceApr,
+                        cooOtsController2AmpliControlModeConfigVal,
+                        cooOtsController2EAmpliPowerConfigVal,
+                        cooOtsController2Temperature,
+                        cooOtsController2Voltage
+                    }
+    STATUS          current
+    DESCRIPTION
+        "The collection of objects to allow configurations and give
+        information related to the optical OTS characteristics
+        for interfaces of ifType opticalTransport(196) using the
+        controller2 table."
+    ::= { ciscoOpticalOtsMIBGroups 14 }
+
 END
 
 
+-- %DNP%  MLC -Submitted MLC
+
+-- %DNP%  MOS -cooOtsOchControllerFrequency MOS
+
+-- %DNP%  MOS -cooOtsOchControllerWidth MOS
+
+-- %DNP%  MOS -cooOtsOchGroup MOS
+
+-- %DNP%  MOS -cooOtsOchControllerFrequency MOS
+
+-- %DNP%  MOS -cooOtsOchControllerWidth MOS
+
+-- %DNP%  MOS -cooOtsOchGroup MOS


### PR DESCRIPTION
From: Ashish Bhutada (abhutada) <abhutada@cisco.com>
Date: Thursday, 19 February 2026 at 12:12 PM
Subject: Re: Add New Entry Table in snmp mib repo

Hi Raghu,
We have committed the new table CooOtsController2Table and its corresponding entries to the CISCO‑OPTICAL‑OTS‑MIB.my file under CDETS: CSCwt02958.
Diff reference: /ws/abhutada-sjc/CISCO-OPTICAL-OTS-MIB_NXOS.patch
For complete file : /ws/abhutada-sjc/CISCO-OPTICAL-OTS-MIB.my

The new OIDs for this table have been registered in the range 834.1.1.7.1.1 to 834.1.1.7.1.48.
Could you please help to publish this updated MIB (including the newly registered OIDs and CooOtsController2Table) to the Cisco public MIB repository 
Please let me know if any additional information is required from my side.

Regards, 
Ashish CB